### PR TITLE
fix: links and typo

### DIFF
--- a/src/app/content/challenges/anchor-vault/en/challenge.mdx
+++ b/src/app/content/challenges/anchor-vault/en/challenge.mdx
@@ -63,7 +63,7 @@ pub enum VaultError {
 ```
 </Codeblock>
 
-**Note**: remember to chagne the program ID to `22222222222222222222222222222222222222222222` since we use this under the hood to test your program.
+**Note**: remember to change the program ID to `22222222222222222222222222222222222222222222` since we use this under the hood to test your program.
 
 <ArticleSection name="Accounts" id="accounts" level="h2" />
 
@@ -175,7 +175,6 @@ First, let's check if the vault has any lamports to withdraw:
 // Check if vault has any lamports
 require_neq!(ctx.accounts.vault.lamports(), 0, VaultError::InvalidAmount);
 ```
-
 </Codeblock>
 
 Then, we need to create the PDA signer seeds and perform the transfer:

--- a/src/app/content/courses/spl-token-with-web3js/introduction/en.mdx
+++ b/src/app/content/courses/spl-token-with-web3js/introduction/en.mdx
@@ -2,7 +2,7 @@ import { ArticleSection } from "../../../../components/ArticleSection/ArticleSec
 
 # The Token Program
 
-On Solana everything token related is handled by the [SPL Token Program](https://github.com/solana-program/token) and the [Token2022 Program](en/courses/token-2022-program): Solana's native token framework that defines how all tokens are created, managed, and transferred. 
+On Solana everything token related is handled by the [SPL Token Program](https://github.com/solana-program/token) and the [Token2022 Program](/en/courses/token-2022-program): Solana's native token framework that defines how all tokens are created, managed, and transferred. 
 
 It's a single, unified program that handles all token operations across the network, ensuring consistency and interoperability.
 

--- a/src/app/content/courses/token-2022-with-anchor/introduction/en.mdx
+++ b/src/app/content/courses/token-2022-with-anchor/introduction/en.mdx
@@ -6,7 +6,7 @@ The Token2022 Program, also known as Token Extensions, is a superset of the func
 
 If you want to learn more about what additional functionalities are available and what are the differences with the Legacy token program, go follow [this course](/en/courses/token-2022-program)  
 
-> If you're not familiar with anchor, we advise you to go through our [introduction to anchor course](en/courses/introduction-to-anchor) before moving forward.
+> If you're not familiar with anchor, we advise you to go through our [introduction to anchor course](/en/courses/introduction-to-anchor) before moving forward.
 
 For anchor, everything token related can be found in the `anchor-spl` crate. For this reason, after having initialized an `Anchor` workspace we can just do:
 
@@ -94,7 +94,7 @@ pub struct CreateAssociatedToken<'info> {
         associated_token::authority = signer,
         associated_token::token_program = token_program,
     )]
-    pub associated_token: InterfaceAccounts<'info, TokenAccount>,
+    pub associated_token: InterfaceAccount<'info, TokenAccount>,
     pub system_program: Program<'info, System>,
     pub token_program: Interface<'info, TokenInterface>,
 }
@@ -118,7 +118,7 @@ pub struct CreateToken<'info> {
         token::authority = signer,
         token::token_program = token_program,
     )]
-    pub token: InterfaceAccounts<'info, TokenAccount>,
+    pub token: InterfaceAccount<'info, TokenAccount>,
     pub system_program: Program<'info, System>,
     pub token_program: Interface<'info, TokenInterface>,
 }


### PR DESCRIPTION
- Fix relative link (leading to 404 error) 
- Fix typo `chagne` to `change`
- Fix typo `InterfaceAccounts` to `InterfaceAccount`