### PR TITLE
fix: code formatting in anchor challenges

### DIFF
--- a/src/app/content/challenges/anchor-escrow/en/challenge.mdx
+++ b/src/app/content/challenges/anchor-escrow/en/challenge.mdx
@@ -1,3 +1,6 @@
+import { ArticleSection } from "../../../../components/ArticleSection/ArticleSection";
+import { Codeblock } from "../../../../components/Codeblock/Codeblock";
+
 ![Anchor Escrow Challenge](/graphics/challenge-banners/anchor-escrow.png)
 
 # The Escrow
@@ -19,14 +22,14 @@ In this challenge, we're going to implement this concept through three simple bu
 
 Let's start by creating a fresh Anchor workspace:
 
-```
+```bash
 anchor init blueshift_anchor_escrow
 cd blueshift_anchor_escrow
 ```
 
 We then continue by enabling `init-if-needed` on the `anchor-lang` crate and by adding the `anchor-spl` crate as well:
 
-```
+```bash
 cargo add anchor-lang --features init-if-needed
 cargo add anchor-spl
 ```
@@ -79,22 +82,22 @@ use instructions::*;
 declare_id!("22222222222222222222222222222222222222222222");
 
 #[program]
-  pub mod blueshift_anchor_escrow {
+pub mod blueshift_anchor_escrow {
     use super::*;
 
     #[instruction(discriminator = 0)]
     pub fn make(ctx: Context<Make>, seed: u64, receive: u64, amount: u64) -> Result<()> {
-      //...
+        //...
     }
 
     #[instruction(discriminator = 1)]
     pub fn take(ctx: Context<Take>) -> Result<()> {
-      //...
+        //...
     }
 
     #[instruction(discriminator = 2)]
     pub fn refund(ctx: Context<Refund>) -> Result<()> {
-      //...
+        //...
     }
 }
 ```
@@ -112,13 +115,13 @@ use anchor_lang::prelude::*;
 
 #[derive(InitSpace)]
 #[account(discriminator = 1)]
-  pub struct Escrow {
-  pub seed: u64,
-  pub maker: Pubkey,
-  pub mint_a: Pubkey,
-  pub mint_b: Pubkey,
-  pub receive: u64,
-  pub bump: u8,
+pub struct Escrow {
+    pub seed: u64,
+    pub maker: Pubkey,
+    pub mint_a: Pubkey,
+    pub mint_b: Pubkey,
+    pub receive: u64,
+    pub bump: u8,
 }
   ```
 </Codeblock>
@@ -144,14 +147,14 @@ use anchor_lang::prelude::*;
 
 #[error_code]
 pub enum EscrowError {
-  #[msg("Invalid amount")]
-  InvalidAmount,
-  #[msg("Invalid maker")]
-  InvalidMaker,
-  #[msg("Invalid mint a")]
-  InvalidMintA,
-  #[msg("Invalid mint b")]
-  InvalidMintB,
+    #[msg("Invalid amount")]
+    InvalidAmount,
+    #[msg("Invalid maker")]
+    InvalidMaker,
+    #[msg("Invalid mint a")]
+    InvalidMintA,
+    #[msg("Invalid mint b")]
+    InvalidMintB,
 }
 ```
 </Codeblock>

--- a/src/app/content/challenges/anchor-escrow/en/pages/make.mdx
+++ b/src/app/content/challenges/anchor-escrow/en/pages/make.mdx
@@ -1,3 +1,6 @@
+import { ArticleSection } from "../../../../../components/ArticleSection/ArticleSection";
+import { Codeblock } from "../../../../../components/Codeblock/Codeblock";
+
 <ArticleSection name="Make" id="make" level="h2" />
 
 We can now move to the `make` instruction, that lives in the `make.rs` and will perform this actions:
@@ -24,46 +27,46 @@ And with all the constraint it will look something like this:
 ```rust
 #[instruction(seed: u64)]
 pub struct Make<'info> {
-  #[account(mut)]
-  pub maker: Signer<'info>,
-  #[account(
-    init,
-    payer = maker,
-    space = Escrow::INIT_SPACE + Escrow::DISCRIMINATOR.len(),
-    seeds = [b"escrow", maker.key().as_ref(), seed.to_le_bytes().as_ref()],
-    bump,
-  )]
-  pub escrow: Account<'info, Escrow>,
+    #[account(mut)]
+    pub maker: Signer<'info>,
+    #[account(
+        init,
+        payer = maker,
+        space = Escrow::INIT_SPACE + Escrow::DISCRIMINATOR.len(),
+        seeds = [b"escrow", maker.key().as_ref(), seed.to_le_bytes().as_ref()],
+        bump,
+    )]
+    pub escrow: Account<'info, Escrow>,
 
-  /// Token Accounts
-  #[account(
-    mint::token_program = token_program
-  )]
-  pub mint_a: InterfaceAccount<'info, Mint>,
-  #[account(
-    mint::token_program = token_program
-  )]
-  pub mint_b: InterfaceAccount<'info, Mint>,
-  #[account(
-    mut,
-    associated_token::mint = mint_a,
-    associated_token::authority = maker,
-    associated_token::token_program = token_program
-  )]
-  pub maker_ata_a: InterfaceAccount<'info, TokenAccount>,
-  #[account(
-    init,
-    payer = maker,
-    associated_token::mint = mint_a,
-    associated_token::authority = escrow,
-    associated_token::token_program = token_program
-  )]
-  pub vault: InterfaceAccount<'info, TokenAccount>,
+    /// Token Accounts
+    #[account(
+        mint::token_program = token_program
+    )]
+    pub mint_a: InterfaceAccount<'info, Mint>,
+    #[account(
+        mint::token_program = token_program
+    )]
+    pub mint_b: InterfaceAccount<'info, Mint>,
+    #[account(
+        mut,
+        associated_token::mint = mint_a,
+        associated_token::authority = maker,
+        associated_token::token_program = token_program
+    )]
+    pub maker_ata_a: InterfaceAccount<'info, TokenAccount>,
+    #[account(
+        init,
+        payer = maker,
+        associated_token::mint = mint_a,
+        associated_token::authority = escrow,
+        associated_token::token_program = token_program
+    )]
+    pub vault: InterfaceAccount<'info, TokenAccount>,
 
-  /// Programs
-  pub associated_token_program: Program<'info, AssociatedToken>,
-  pub token_program: Interface<'info, TokenInterface>,
-  pub system_program: Program<'info, System>,
+    /// Programs
+    pub associated_token_program: Program<'info, AssociatedToken>,
+    pub token_program: Interface<'info, TokenInterface>,
+    pub system_program: Program<'info, System>,
 }
 ```
 </Codeblock>
@@ -79,35 +82,38 @@ We start by populating the `Escrow` using the `set_inner()` helper, and we then 
 <Codeblock lang="rust">
 ```rust
 impl<'info> Make<'info> {
-  /// # Create the Escrow
-  fn populate_escrow(&mut self, seed: u64, amount: u64, bump: u8) -> Result<()> {
-    self.escrow.set_inner(Escrow {
-      seed,
-      maker: self.maker.key(),
-      mint_a: self.mint_a.key(),
-      mint_b: self.mint_b.key(),
-      receive: amount,
-      bump,
-    });
+    /// # Create the Escrow
+    fn populate_escrow(&mut self, seed: u64, amount: u64, bump: u8) -> Result<()> {
+        self.escrow.set_inner(Escrow {
+            seed,
+            maker: self.maker.key(),
+            mint_a: self.mint_a.key(),
+            mint_b: self.mint_b.key(),
+            receive: amount,
+            bump,
+        });
 
-    Ok(())
-  }
+        Ok(())
+    }
 
-  /// # Deposit the tokens
-  fn deposit_tokens(&self, amount: u64) -> Result<()> {
-    transfer_checked(
-      CpiContext::new(
-        self.token_program.to_account_info(),
-        TransferChecked {
-          from: self.maker_ata_a.to_account_info(),
-          mint: self.mint_a.to_account_info(),
-          to: self.vault.to_account_info(),
-          authority: self.maker.to_account_info(),
-      }), amount, self.mint_a.decimals
-    )?;
+    /// # Deposit the tokens
+    fn deposit_tokens(&self, amount: u64) -> Result<()> {
+        transfer_checked(
+            CpiContext::new(
+                self.token_program.to_account_info(),
+                TransferChecked {
+                    from: self.maker_ata_a.to_account_info(),
+                    mint: self.mint_a.to_account_info(),
+                    to: self.vault.to_account_info(),
+                    authority: self.maker.to_account_info(),
+                },
+            ),
+            amount,
+            self.mint_a.decimals,
+        )?;
 
-    Ok(())
-  }
+        Ok(())
+    }
 }
 ```
 </Codeblock>
@@ -121,17 +127,17 @@ And now we can move onto creating an `handler` function where we perform some ch
 <Codeblock lang="rust">
 ```rust
 pub fn handler(ctx: Context<Make>, seed: u64, receive: u64, amount: u64) -> Result<()> {
-  // Validate the amount
-  require_gte!(receive, 0, EscrowError::InvalidAmount);
-  require_gte!(amount, 0, EscrowError::InvalidAmount);
+    // Validate the amount
+    require_gte!(receive, 0, EscrowError::InvalidAmount);
+    require_gte!(amount, 0, EscrowError::InvalidAmount);
 
-  // Save the Escrow Data
-  ctx.accounts.populate_escrow(seed, receive, ctx.bumps.escrow)?;
+    // Save the Escrow Data
+    ctx.accounts.populate_escrow(seed, receive, ctx.bumps.escrow)?;
 
-  // Deposit Tokens
-  ctx.accounts.deposit_tokens(amount)?;
+    // Deposit Tokens
+    ctx.accounts.deposit_tokens(amount)?;
 
-  Ok(())
+    Ok(())
 }
   ```
 </Codeblock>

--- a/src/app/content/challenges/anchor-escrow/en/pages/refund.mdx
+++ b/src/app/content/challenges/anchor-escrow/en/pages/refund.mdx
@@ -1,3 +1,6 @@
+import { ArticleSection } from "../../../../../components/ArticleSection/ArticleSection";
+import { Codeblock } from "../../../../../components/Codeblock/Codeblock";
+
 <ArticleSection name="Refund" id="refund" level="h2" />
 
 We can now move to the `refund` instruction, that lives in the `refund.rs` and will perform this actions:
@@ -57,7 +60,7 @@ You can now test your program against our unit tests and claim your NFTs!
 
 Start by building your program using the following command in your terminal
 
-```
+```bash
 anchor build
 ```
 

--- a/src/app/content/challenges/anchor-escrow/en/pages/take.mdx
+++ b/src/app/content/challenges/anchor-escrow/en/pages/take.mdx
@@ -1,3 +1,6 @@
+import { ArticleSection } from "../../../../../components/ArticleSection/ArticleSection";
+import { Codeblock } from "../../../../../components/Codeblock/Codeblock";
+
 <ArticleSection name="Take" id="take" level="h2" />
 
 We can now move to the `take` instruction, that lives in the `take.rs` and will perform this actions:
@@ -27,59 +30,59 @@ And with all the constraint it will look something like this:
   ```rust
 #[derive(Accounts)]
 pub struct Take<'info> {
-  #[account(mut)]
-  pub taker: Signer<'info>,
-  #[account(mut)]
-  pub maker: SystemAccount<'info>,
-  #[account(
-    mut,
-    close = maker,
-    seeds = [b"escrow", maker.key().as_ref(), escrow.seed.to_le_bytes().as_ref()],
-    bump = escrow.bump,
-    has_one = maker @ EscrowError::InvalidMaker,
-    has_one = mint_a @ EscrowError::InvalidMintA,
-    has_one = mint_b @ EscrowError::InvalidMintB,
-  )]
-  pub escrow: Box<Account<'info, Escrow>>,
+    #[account(mut)]
+    pub taker: Signer<'info>,
+    #[account(mut)]
+    pub maker: SystemAccount<'info>,
+    #[account(
+        mut,
+        close = maker,
+        seeds = [b"escrow", maker.key().as_ref(), escrow.seed.to_le_bytes().as_ref()],
+        bump = escrow.bump,
+        has_one = maker @ EscrowError::InvalidMaker,
+        has_one = mint_a @ EscrowError::InvalidMintA,
+        has_one = mint_b @ EscrowError::InvalidMintB,
+    )]
+    pub escrow: Box<Account<'info, Escrow>>,
 
-  /// Token Accounts
-  pub mint_a: Box<InterfaceAccount<'info, Mint>>,
-  pub mint_b: Box<InterfaceAccount<'info, Mint>>,
-  #[account(
-    mut,
-    associated_token::mint = mint_a,
-    associated_token::authority = escrow,
-    associated_token::token_program = token_program
-  )]
-  pub vault: Box<InterfaceAccount<'info, TokenAccount>>,
-  #[account(
-    init_if_needed,
-    payer = taker,
-    associated_token::mint = mint_a,
-    associated_token::authority = taker,
-    associated_token::token_program = token_program
-  )]
-  pub taker_ata_a: Box<InterfaceAccount<'info, TokenAccount>>,
-  #[account(
-    mut,
-    associated_token::mint = mint_b,
-    associated_token::authority = taker,
-    associated_token::token_program = token_program
-  )]
-  pub taker_ata_b: Box<InterfaceAccount<'info, TokenAccount>>,
-  #[account(
-    init_if_needed,
-    payer = taker,
-    associated_token::mint = mint_b,
-    associated_token::authority = maker,
-    associated_token::token_program = token_program
-  )]
-  pub maker_ata_b: Box<InterfaceAccount<'info, TokenAccount>>,
+    /// Token Accounts
+    pub mint_a: Box<InterfaceAccount<'info, Mint>>,
+    pub mint_b: Box<InterfaceAccount<'info, Mint>>,
+    #[account(
+        mut,
+        associated_token::mint = mint_a,
+        associated_token::authority = escrow,
+        associated_token::token_program = token_program
+    )]
+    pub vault: Box<InterfaceAccount<'info, TokenAccount>>,
+    #[account(
+        init_if_needed,
+        payer = taker,
+        associated_token::mint = mint_a,
+        associated_token::authority = taker,
+        associated_token::token_program = token_program
+    )]
+    pub taker_ata_a: Box<InterfaceAccount<'info, TokenAccount>>,
+    #[account(
+        mut,
+        associated_token::mint = mint_b,
+        associated_token::authority = taker,
+        associated_token::token_program = token_program
+    )]
+    pub taker_ata_b: Box<InterfaceAccount<'info, TokenAccount>>,
+    #[account(
+        init_if_needed,
+        payer = taker,
+        associated_token::mint = mint_b,
+        associated_token::authority = maker,
+        associated_token::token_program = token_program
+    )]
+    pub maker_ata_b: Box<InterfaceAccount<'info, TokenAccount>>,
 
-  /// Programs
-  pub associated_token_program: Program<'info, AssociatedToken>,
-  pub token_program: Interface<'info, TokenInterface>,
-  pub system_program: Program<'info, System>,
+    /// Programs
+    pub associated_token_program: Program<'info, AssociatedToken>,
+    pub token_program: Interface<'info, TokenInterface>,
+    pub system_program: Program<'info, System>,
 }
   ```
 </Codeblock>
@@ -91,60 +94,62 @@ In the logic we then start by transfering the tokens from the `taker_ata_b` to t
 <Codeblock lang="rust">
 ```rust
 impl<'info> Take<'info> {
-  fn transfer_to_maker(&mut self) -> Result<()> {
-    transfer_checked(
-      CpiContext::new(
-        self.token_program.to_account_info(),
-          TransferChecked {
-          from: self.taker_ata_b.to_account_info(),
-          to: self.maker_ata_b.to_account_info(),
-          mint: self.mint_b.to_account_info(),
-          authority: self.taker.to_account_info(),
-        },
-      ), self.escrow.receive, self.mint_b.decimals
-    )?;
+    fn transfer_to_maker(&mut self) -> Result<()> {
+        transfer_checked(
+            CpiContext::new(
+                self.token_program.to_account_info(),
+                TransferChecked {
+                    from: self.taker_ata_b.to_account_info(),
+                    to: self.maker_ata_b.to_account_info(),
+                    mint: self.mint_b.to_account_info(),
+                    authority: self.taker.to_account_info(),
+                },
+            ),
+            self.escrow.receive,
+            self.mint_b.decimals,
+        )?;
 
-    Ok(())
-  }
+        Ok(())
+    }
 
-  fn withdraw_and_close_vault(&mut self) -> Result<()> {
-    // Create the signer seeds for the Vault
-    let signer_seeds: [&[&[u8]]; 1] = [&[
-      b"escrow",
-      self.maker.to_account_info().key.as_ref(),
-      &self.escrow.seed.to_le_bytes()[..],
-      &[self.escrow.bump],
-    ]];
+    fn withdraw_and_close_vault(&mut self) -> Result<()> {
+        // Create the signer seeds for the Vault
+        let signer_seeds: [&[&[u8]]; 1] = [&[
+            b"escrow",
+            self.maker.to_account_info().key.as_ref(),
+            &self.escrow.seed.to_le_bytes()[..],
+            &[self.escrow.bump],
+        ]];
 
-    // Transfer Token A (Vault -> Taker)
-    transfer_checked(
-      CpiContext::new_with_signer(
-        self.token_program.to_account_info(),
-        TransferChecked {
-          from: self.vault.to_account_info(),
-          to: self.taker_ata_a.to_account_info(),
-          mint: self.mint_a.to_account_info(),
-          authority: self.escrow.to_account_info(),
-        },
-        &signer_seeds
-      ), self.vault.amount, self.mint_a.decimals
-    )?;
+        // Transfer Token A (Vault -> Taker)
+        transfer_checked(
+            CpiContext::new_with_signer(
+                self.token_program.to_account_info(),
+                TransferChecked {
+                    from: self.vault.to_account_info(),
+                    to: self.taker_ata_a.to_account_info(),
+                    mint: self.mint_a.to_account_info(),
+                    authority: self.escrow.to_account_info(),
+                },
+                &signer_seeds,
+            ),
+            self.vault.amount,
+            self.mint_a.decimals,
+        )?;
 
-    // Close the Vault
-    close_account(
-      CpiContext::new_with_signer(
-        self.token_program.to_account_info(),
-        CloseAccount {
-          account: self.vault.to_account_info(),
-          authority: self.escrow.to_account_info(),
-          destination: self.maker.to_account_info(),
-        },
-        &signer_seeds
-      )
-    )?;
+        // Close the Vault
+        close_account(CpiContext::new_with_signer(
+            self.token_program.to_account_info(),
+            CloseAccount {
+                account: self.vault.to_account_info(),
+                authority: self.escrow.to_account_info(),
+                destination: self.maker.to_account_info(),
+            },
+            &signer_seeds,
+        ))?;
 
-    Ok(())
-  }
+        Ok(())
+    }
 }
 ```
 </Codeblock>
@@ -154,13 +159,13 @@ We know create the `handler` function and this time luckily we don't need to per
 <Codeblock lang="rust">
 ```rust
 pub fn handler(ctx: Context<Take>) -> Result<()> {
-  // Transfer Token B to Maker
-  ctx.accounts.transfer_to_maker()?;
+    // Transfer Token B to Maker
+    ctx.accounts.transfer_to_maker()?;
 
-  // Withdraw and close the Vault
-  ctx.accounts.withdraw_and_close_vault()?;
+    // Withdraw and close the Vault
+    ctx.accounts.withdraw_and_close_vault()?;
 
-  Ok(())
+    Ok(())
 }
 ```
 </Codeblock>

--- a/src/app/content/challenges/anchor-vault/en/challenge.mdx
+++ b/src/app/content/challenges/anchor-vault/en/challenge.mdx
@@ -1,7 +1,6 @@
 import { ArticleSection } from "../../../../components/ArticleSection/ArticleSection";
 import { Codeblock } from "../../../../components/Codeblock/Codeblock";
 
-
 ![Anchor Vault Challenge](/graphics/challenge-banners/anchor-vault.png)
 
 # The Vault
@@ -14,7 +13,7 @@ In this challenge, we'll build a simple lamport vault that demonstrates how to w
 
 Before you begin, be sure Rust and Anchor are installed (see the [official documentation](https://www.anchor-lang.com/docs/installation) if you need a refresher). Then in your terminal run:
 
-```
+```bash
 anchor init blueshift_anchor_vault
 ```
 
@@ -30,35 +29,35 @@ declare_id!("22222222222222222222222222222222222222222222");
 
 #[program]
 pub mod blueshift_anchor_vault {
-  use super::*;
+    use super::*;
 
-  pub fn deposit(ctx: Context<VaultAction>, amount: u64) -> Result<()> {
-    // deposit logic
-    Ok(())
-  }
+    pub fn deposit(ctx: Context<VaultAction>, amount: u64) -> Result<()> {
+        // deposit logic
+        Ok(())
+    }
 
-  pub fn withdraw(ctx: Context<VaultAction>) -> Result<()> {
-    // withdraw logic
-    Ok(())
-  }
+    pub fn withdraw(ctx: Context<VaultAction>) -> Result<()> {
+        // withdraw logic
+        Ok(())
+    }
 }
 
 #[derive(Accounts)]
 pub struct VaultAction<'info> {
-  #[account(mut)]
-  pub signer: Signer<'info>,
-  #[account(
-    mut,
-    seeds = [b"vault", signer.key().as_ref()],
-    bump,
-  )]
-  pub vault: SystemAccount<'info>,
-  pub system_program: Program<'info, System>,
+    #[account(mut)]
+    pub signer: Signer<'info>,
+    #[account(
+        mut,
+        seeds = [b"vault", signer.key().as_ref()],
+        bump,
+    )]
+    pub vault: SystemAccount<'info>,
+    pub system_program: Program<'info, System>,
 }
 
 #[error_code]
 pub enum VaultError {
-  // error enum
+    // error enum
 }
 ```
 </Codeblock>
@@ -80,15 +79,15 @@ Here's how we define the account struct:
 ```rust
 #[derive(Accounts)]
 pub struct VaultAction<'info> {
-  #[account(mut)]
-  pub signer: Signer<'info>,
-  #[account(
-    mut,
-    seeds = [b"vault", signer.key().as_ref()],
-    bump,
-  )]
-  pub vault: SystemAccount<'info>,
-  pub system_program: Program<'info, System>,
+    #[account(mut)]
+    pub signer: Signer<'info>,
+    #[account(
+        mut,
+        seeds = [b"vault", signer.key().as_ref()],
+        bump,
+    )]
+    pub vault: SystemAccount<'info>,
+    pub system_program: Program<'info, System>,
 }
 ```
 </Codeblock>
@@ -113,10 +112,10 @@ It will look something like this:
 ```rust
 #[error_code]
 pub enum VaultError {
-  #[msg("Vault already exists")]
-  VaultAlreadyExists,
-  #[msg("Invalid amount")]
-  InvalidAmount,
+    #[msg("Vault already exists")]
+    VaultAlreadyExists,
+    #[msg("Invalid amount")]
+    InvalidAmount,
 }
 ```
 </Codeblock>
@@ -151,13 +150,15 @@ Once the checks pass, Anchor's System Program helper calls the `Transfer` CPI li
 use anchor_lang::system_program::{transfer, Transfer};
 
 transfer(
-  CpiContext::new(
-    ctx.accounts.system_program.to_account_info(),
-    Transfer {
-      from: ctx.accounts.signer.to_account_info(),
-      to: ctx.accounts.vault.to_account_info(),
-    }
-  ), amount)?;
+    CpiContext::new(
+        ctx.accounts.system_program.to_account_info(),
+        Transfer {
+            from: ctx.accounts.signer.to_account_info(),
+            to: ctx.accounts.vault.to_account_info(),
+        },
+    ),
+    amount,
+)?;
 ```
 </Codeblock>
 
@@ -187,15 +188,15 @@ let signer_seeds = &[b"vault", signer_key.as_ref(), &[ctx.bumps.vault]];
 
 // Transfer all lamports from vault to signer
 transfer(
-  CpiContext::new_with_signer(
-    ctx.accounts.system_program.to_account_info(),
-    Transfer {
-      from: ctx.accounts.vault.to_account_info(),
-      to: ctx.accounts.signer.to_account_info(),
-    },
-    &[&signer_seeds[..]]
-  ),
-  ctx.accounts.vault.lamports()
+    CpiContext::new_with_signer(
+        ctx.accounts.system_program.to_account_info(),
+        Transfer {
+            from: ctx.accounts.vault.to_account_info(),
+            to: ctx.accounts.signer.to_account_info(),
+        },
+        &[&signer_seeds[..]]
+    ),
+    ctx.accounts.vault.lamports()
 )?;
 ```
 </Codeblock>
@@ -210,13 +211,10 @@ You can now test your program against our unit tests and claim your NFTs!
 
 Start by building your program using the following command in your terminal
 
-```
+```bash
 anchor build
 ```
 
 This generated a `.so` file directly in your `target/deploy` folder. 
 
 Now click on the `take challenge` button and drop the file there!
-
-
-


### PR DESCRIPTION
1.  Added `bash` specifier for terminal commands

Before the first line of multiline blocks was shifted:
<img width="472" height="85" alt="image" src="https://github.com/user-attachments/assets/b5e65be1-a39b-4516-a938-21aae73599b4" />

Now:
<img width="392" height="77" alt="image" src="https://github.com/user-attachments/assets/bf4c7ac2-552b-4a5b-a875-40d23966e77a" />

2. Changed the indentations for rust code from 2 spaces to 4.
