### PR TITLE
fix: wrong example code

### DIFF
--- a/src/app/content/courses/spl-token-with-web3js/introduction/en.mdx
+++ b/src/app/content/courses/spl-token-with-web3js/introduction/en.mdx
@@ -130,7 +130,7 @@ console.log(`Token created! Check out your TX here: https://explorer.solana.com/
 But same as the `Mint` account, the `@solana/spl-token` package has some abstraction to create the `Token` account. We can use the `createAccount()` function like so:
 
 ```ts
-const mint = await createMint(
+const token = await createAccount(
     connection, // connection
     keypair, // payer
     mint.publicKey, // mint pubkey


### PR DESCRIPTION
wrong example code for token account generation