### PR TITLE
fix: doubled sentences in token-2022-program course

### DIFF
--- a/src/app/content/courses/token-2022-program/introduction/en.mdx
+++ b/src/app/content/courses/token-2022-program/introduction/en.mdx
@@ -16,9 +16,7 @@ In the previous section we talked about the fact that the main difference betwee
 
 To be enforceable, these extensions need to live directly inside the `Mint` and `Token` accounts, since this is the only way to ensure that the ruleset is enforced while operating directly on the token program.
 
-In the previous section we talked about the fact that the main difference between the `Tokenkeg` and `Token2022` program are `Token Extension`. 
-
-For this reason, let's look at the main differences between the legacy and new token programs on these accounts.`
+For this reason, let's look at the main differences between the legacy and new token programs on these accounts.
 
 **Legacy Token Accounts**
 
@@ -115,7 +113,7 @@ Each extension has a discriminator that gets saved with the size of that extensi
 pub struct ExtensionHeader {
     /// Extension Discriminator
     pub discriminator: u16
-    /// Lenght of the Disriminator 
+    /// Lenght of the Disriminator
     pub lenght: u16
 }
 ```

--- a/src/app/content/courses/token-2022-program/token-extensions/en.mdx
+++ b/src/app/content/courses/token-2022-program/token-extensions/en.mdx
@@ -2,13 +2,13 @@ import { ArticleSection } from "../../../../components/ArticleSection/ArticleSec
 
 # Token Extensions
 
-While the original Token program provided essential functionality like minting, transferring, and freezing tokens, Token Extensions unlock a new paradigm of programmable tokens. 
+While the original Token program provided essential functionality like minting, transferring, and freezing tokens, Token Extensions unlock a new paradigm of programmable tokens.
 
 This enhanced program maintains full compatibility with existing SPL Token operations while adding sophisticated features such as transfer hooks for custom logic execution, built-in fee mechanisms, enhanced metadata support, interest-bearing calculations, and advanced security controls.
 
 ### Extension Compatibility
 
-Token Extensions are designed to be composable, allowing you to combine multiple extensions to create tokens that perfectly match your project's requirements. 
+Token Extensions are designed to be composable, allowing you to combine multiple extensions to create tokens that perfectly match your project's requirements.
 
 However, certain combinations are incompatible due to conflicting functionality or logical contradictions like:
 - Non-transferable + transfer hooks / transfer fees / confidential transfer
@@ -47,7 +47,7 @@ pub struct TransferFee {
 
 Some things to point out:
 - The `config_authority` can be different from who actually can withdraw the tokens from the `Token` accounts.
-- We have both an `older` and `newer` transfer fee struct. 
+- We have both an `older` and `newer` transfer fee struct.
 
 The last point is due to the fact there is a "cooldown" period when we set a new `TransferFee` of 2 epochs to avoid rug pulls at the end of an epoch. This means that for the first 2 epochs of a new `TransferFee`, the older `TransferFee` is the one that is actually active.
 
@@ -146,10 +146,8 @@ pub struct MemoTranfer {
 The `NonTransferable` extension is a `Mint` account extension that prevents tokens from being transferred between accounts, making them permanently bound to their current holders.
 
 This extension is useful for creating soulbound tokens, achievement badges, certificates, or any token that represents a non-transferable right or status. Once minted to an account, these tokens cannot be moved, sold, or transferred to another wallet, ensuring they remain permanently associated with the original recipient.
-A
-dditionally, the `Token` account associated with a `Mint` that has the `NonTransferable` extension will come with the `NonTransferableAccount` extension.
 
-The `NonTransferable Extension` is a `Mint` account extension that enforces that all incoming transfers to a token account include a memo, facilitating enhanced transaction tracking and user identification.
+Additionally, the `Token` account associated with a `Mint` that has the `NonTransferable` extension will come with the `NonTransferableAccount` extension.
 
 This is how the `NonTransferable` and `NonTransferableAccount` extension data looks:
 
@@ -184,7 +182,7 @@ pub struct InterestBearing {
 }
 ```
 
-Since the rate can be updated, to make sure that the calculation are correct, there is a `pre_update_average_rate` field that is used during calculation how to behave in case of an updated rate. 
+Since the rate can be updated, to make sure that the calculation are correct, there is a `pre_update_average_rate` field that is used during calculation how to behave in case of an updated rate.
 
 <ArticleSection name="Cpi Guard Extension" id="cpi-guard-extension" level="h2" />
 
@@ -215,7 +213,7 @@ pub struct CpiGuard {
 
 The `PermanentDelegate` extension is a `Mint` account extension that allows a permanent delegate for all tokens of the mint that is capable of transferring or burning any token of that mint, from any token account.
 
-This extension is useful for creating tokens with built-in administrative control, such as stablecoins that need emergency freeze capabilities, gaming tokens that require centralized management, or compliance tokens where a regulator needs permanent oversight. 
+This extension is useful for creating tokens with built-in administrative control, such as stablecoins that need emergency freeze capabilities, gaming tokens that require centralized management, or compliance tokens where a regulator needs permanent oversight.
 
 > Unlike regular delegates which can be revoked, this delegate authority is permanent and immutable.
 
@@ -316,7 +314,7 @@ The `Group` and `Member` extensions are `Mint` account extensions that introduce
 
 This extension system is perfect for creating NFT collections, token families, or any grouping of related assets where you need to track membership and enforce collection limits. Groups can represent collections while members represent individual items within those collections.
 
-oth the Group and Member extensions are composed of 2 different extensions that both go on a `Mint` account, just like the `Metadata` extension:
+Both the Group and Member extensions are composed of 2 different extensions that both go on a `Mint` account, just like the `Metadata` extension:
 - The `Extension` that contains all the information about the group or member.
 - The `Pointer Extension` that references the Mint account where the `Group` or `Member` extension lives.
 


### PR DESCRIPTION
Some sentences are copies of sentences a little above. Also fixed couple of typos