### PR TITLE
Feat: Add copy-to-clipboard button to code blocks for easier copying

### DIFF
--- a/mdx-components.tsx
+++ b/mdx-components.tsx
@@ -27,5 +27,22 @@ export function useMDXComponents(components: MDXComponents): MDXComponents {
         {children}
       </blockquote>
     ),
+    pre: ({ children, ...props }) => {
+      if (
+        children &&
+        typeof children === "object" &&
+        "props" in children &&
+        children.props
+      ) {
+        const { className = "", children: codeChildren } = children.props;
+        const lang = className.replace("language-", "") || "";
+        return (
+          <Codeblock lang={lang}>
+            {codeChildren}
+          </Codeblock>
+        );
+      }
+      return <pre {...props}>{children}</pre>;
+    },
   };
 }

--- a/src/app/components/Codeblock/Codeblock.tsx
+++ b/src/app/components/Codeblock/Codeblock.tsx
@@ -13,27 +13,29 @@ export function Codeblock({
   children: React.ReactNode;
   lang: string;
 }) {
-  const preRef = useRef<HTMLDivElement>(null);
+  const preRef = useRef<HTMLPreElement>(null);
+  const inlineRef = useRef<HTMLElement>(null);
   const [isCopied, setIsCopied] = useState(false);
 
   const handleClickCopy = async () => {
-    const code = preRef.current?.textContent;
-
+    const code = inlineRef.current?.textContent || preRef.current?.textContent;
     if (!code) return;
-
     await navigator.clipboard.writeText(code);
     setIsCopied(true);
-
     setTimeout(() => {
       setIsCopied(false);
     }, 3000);
   };
 
+
+  const codeText = typeof children === "string" ? children : Array.isArray(children) ? children.join("") : "";
+  const isSingleLine = codeText.trim().split("\n").length === 1;
+
   return (
-    <div className="flex flex-col w-full border border-border rounded-xl overflow-hidden !my-8">
-      <div className="text-sm font-medium text-brand-secondary flex items-center justify-between px-6 py-3 border-b-border bg-background-card-foreground rounded-t-xl">
-        {lang}
-        {children && (
+    <div className="relative w-full border border-border rounded-xl overflow-hidden !my-8 bg-background-card">
+      {isSingleLine ? (
+        <div className="flex items-center min-h-[40px] px-4 py-1 bg-background-card relative">
+          <code ref={inlineRef} className="flex-1 text-brand-secondary whitespace-pre text-base">{children}</code>
           <motion.div
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
@@ -44,23 +46,71 @@ export function Codeblock({
               if (isCopied) return;
               handleClickCopy();
             }}
+            className={classNames(
+              "ml-2 p-1 bg-background-card-foreground rounded-md cursor-pointer transition",
+              {
+                "!text-brand-primary !cursor-default": isCopied,
+                "hover:bg-background-primary": !isCopied,
+              }
+            )}
+            title={isCopied ? "Copied!" : "Copy to clipboard"}
+            style={{ boxShadow: "0 1px 4px 0 rgba(0,0,0,0.04)" }}
           >
             <Icon
               name={isCopied ? "Success" : "Copy"}
               size={16 as 18 | 14 | 12}
               className={classNames(
-                "text-mute hover:text-secondary transition cursor-pointer",
+                "text-mute transition",
                 {
                   "!text-brand-primary !cursor-default": isCopied,
                 }
               )}
             />
           </motion.div>
-        )}
-      </div>
-      <div className="bg-background-card" ref={preRef}>
-        {children}
-      </div>
+        </div>
+      ) : (
+        <>
+          <motion.div
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.2, ease: anticipate }}
+            key={isCopied ? "success" : "copy"}
+            onClick={() => {
+              if (isCopied) return;
+              handleClickCopy();
+            }}
+            className={classNames(
+              "absolute top-3 right-3 z-10 p-1 bg-background-card-foreground rounded-md cursor-pointer transition",
+              {
+                "!text-brand-primary !cursor-default": isCopied,
+                "hover:bg-background-primary": !isCopied,
+              }
+            )}
+            title={isCopied ? "Copied!" : "Copy to clipboard"}
+            style={{ boxShadow: "0 1px 4px 0 rgba(0,0,0,0.04)" }}
+          >
+            <Icon
+              name={isCopied ? "Success" : "Copy"}
+              size={16 as 18 | 14 | 12}
+              className={classNames(
+                "text-mute transition",
+                {
+                  "!text-brand-primary !cursor-default": isCopied,
+                }
+              )}
+            />
+          </motion.div>
+          <pre className="py-2 px-4 overflow-x-auto bg-transparent m-0" style={{ lineHeight: '1.4' }} ref={preRef}>
+            <code className="block whitespace-pre m-0 p-0" style={{ lineHeight: '1.4' }}>{children}</code>
+          </pre>
+          {lang && (
+            <span className="absolute bottom-2 right-3 text-xs text-brand-secondary opacity-60 select-none pointer-events-none">
+              {lang}
+            </span>
+          )}
+        </>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
- The button appears in the top-right corner of code blocks, making it quick and convenient for users to copy code.
- Supports both single-line and multi-line code blocks.
- Adjusted spacing to ensure the code block layout remains clean and compact.
<table>
  <tr>
    <th>Before (Original Code Block UI)</th>
    <th>After (Improved Code Block UI)</th>
  </tr>
  <tr>
    <td><img width="713" height="387" alt="Before Screenshot" src="https://github.com/user-attachments/assets/ec779543-fa9a-48f2-8f94-26d80b3a08a3" /></td>
    <td>
<img width="713" height="387" alt="Screenshot 2025-07-22 at 5 02 05 PM" src="https://github.com/user-attachments/assets/1e66b94b-1086-4e19-89c3-b0625d1374c1" />
</td>
  </tr>
</table>



