### PR TITLE
fix: add catch-all route for custom 404 page

### DIFF
--- a/src/app/[locale]/[...slug]/page.tsx
+++ b/src/app/[locale]/[...slug]/page.tsx
@@ -1,0 +1,5 @@
+import { notFound } from "next/navigation";
+
+export default async function CatchAllPage() {
+  notFound();
+} 

--- a/src/app/[locale]/not-found.tsx
+++ b/src/app/[locale]/not-found.tsx
@@ -1,7 +1,47 @@
 import { Link } from "@/i18n/navigation";
 import Button from "../components/Button/Button";
+import { headers } from "next/headers";
 
-export default function NotFound() {
+export default async function NotFound() {
+  const headersList = await headers();
+  const pathname = headersList.get("x-current-path") || "";
+  
+
+  const isChallengesRoute = pathname.includes("/challenges");
+  const isCoursesRoute = pathname.includes("/courses");
+  
+  // Set appropriate content based on the route
+  let message: string;
+  let buttons: React.ReactNode;
+  
+  if (isChallengesRoute) {
+    message = "The challenge you are looking for doesn't exist.";
+    buttons = (
+      <Link href="/challenges">
+        <Button icon="ArrowLeft" label="Head to Challenges" />
+      </Link>
+    );
+  } else if (isCoursesRoute) {
+    message = "The course or lesson you are looking for doesn't exist.";
+    buttons = (
+      <Link href="/">
+        <Button icon="ArrowLeft" label="Head to Courses" />
+      </Link>
+    );
+  } else {
+    message = "The page you are looking for doesn't exist.";
+    buttons = (
+      <div className="flex flex-col sm:flex-row gap-4">
+        <Link href="/">
+          <Button icon="ArrowLeft" label="Head to Courses" />
+        </Link>
+        <Link href="/challenges">
+          <Button icon="ArrowLeft" label="Head to Challenges" />
+        </Link>
+      </div>
+    );
+  }
+
   return (
     <div className="flex flex-col gap-y-8 items-center justify-center h-screen">
       <div className="flex flex-col gap-y-2 items-center justify-center">
@@ -9,12 +49,10 @@ export default function NotFound() {
           4<span className="animate-pulse">0</span>4
         </div>
         <p className="text-secondary font-medium">
-          The course or lesson you are looking for doesn't exist.
+          {message}
         </p>
       </div>
-      <Link href="/">
-        <Button icon="ArrowLeft" label="Head to Courses" />
-      </Link>
+      {buttons}
     </div>
   );
 }

--- a/src/app/[locale]/not-found.tsx
+++ b/src/app/[locale]/not-found.tsx
@@ -1,19 +1,18 @@
+"use client";
 import { Link } from "@/i18n/navigation";
 import Button from "../components/Button/Button";
-import { headers } from "next/headers";
+import { usePathname } from "next/navigation";
 
-export default async function NotFound() {
-  const headersList = await headers();
-  const pathname = headersList.get("x-current-path") || "";
-  
+export default function NotFound() {
+  const pathname = usePathname();
 
   const isChallengesRoute = pathname.includes("/challenges");
   const isCoursesRoute = pathname.includes("/courses");
-  
+
   // Set appropriate content based on the route
   let message: string;
   let buttons: React.ReactNode;
-  
+
   if (isChallengesRoute) {
     message = "The challenge you are looking for doesn't exist.";
     buttons = (


### PR DESCRIPTION
## What was broken

1. **Challenge routes showing wrong button**: When you visited `/challenges/xyz` (invalid challenge), it was showing "Head to Courses" button instead of "Head to Challenges"

2. **Root routes using Next.js default error**: Routes like `/en/zysd` were showing the default Next.js error page instead of our custom 404 page

## What I fixed

- Added a catch-all route `[...slug]` to handle invalid paths properly
- Made the 404 page smart - it now shows the right button based on what you were trying to access
- Fixed the layout so all 404 pages use our custom design

## Before/After

### Challenge routes
| Before | After |
|--------|-------|
| ![Wrong button on challenges/xyz](https://github.com/user-attachments/assets/ae54e6b2-4898-4544-8fc6-b28fc029af7d) | ![Corrected button on /challenges/xyz](https://github.com/user-attachments/assets/dc31645a-e779-4a0a-965b-a02d8a93897a) |

### Root level routes  
| Before | After |
|--------|-------|
| ![Root level wrong route error page](https://github.com/user-attachments/assets/b5e75b21-09a9-4f1a-987b-509055372071) | ![Corrected root level route error page](https://github.com/user-attachments/assets/637c8ceb-446c-4698-88e4-2556e9600bd7) |

Now invalid routes show our custom 404 page with the right navigation options! 🎯