### PR TITLE
fix: impl `AccountCheck` trait in the Introduction to Pinocchio course

### DIFF
--- a/src/app/content/courses/introduction-to-pinocchio/pinocchio-accounts/en.mdx
+++ b/src/app/content/courses/introduction-to-pinocchio/pinocchio-accounts/en.mdx
@@ -58,7 +58,7 @@ pub struct SignerAccount;
 
 // Implement the trait for different Types
 impl AccountCheck for SignerAccount {
-    pub fn check(account: &AccountInfo) -> Result<(), ProgramError> {
+    fn check(account: &AccountInfo) -> Result<(), ProgramError> {
         if !account.is_signer() {
             return Err(PinocchioError::NotSigner.into());
         }
@@ -69,7 +69,7 @@ impl AccountCheck for SignerAccount {
 pub struct SystemAccount;
 
 impl AccountCheck for SystemAccount {
-    pub fn check(account: &AccountInfo) -> Result<(), ProgramError> {
+    fn check(account: &AccountInfo) -> Result<(), ProgramError> {
         if !account.is_owned_by(&pinocchio_system::ID) {
             return Err(PinocchioError::InvalidOwner.into());
         }


### PR DESCRIPTION
### Problem
`AccountCheck` trait was implemented for `SignerAccount` and `SystemAccount` with illegal `pub` visibility modifier, in the **Introduction to Pinocchio** course.

### Solution
remove `pub` visibility modifiers from the trait implementation

cc @dhl 