### PR TITLE
fix: token account length in token-2022-program course

### DIFF
--- a/src/app/content/courses/token-2022-program/introduction/en.mdx
+++ b/src/app/content/courses/token-2022-program/introduction/en.mdx
@@ -79,7 +79,7 @@ pub struct Mint {
     /// ...
     /// Padding (83 empty bytes)
     pub padding: [u8; 83]
-    /// Discriminator (0)
+    /// Discriminator (1)
     pub discriminator: u8
     /// Extensions data
     /// ...
@@ -90,18 +90,18 @@ pub struct Mint {
 pub struct Account {
     /// Legacy Token Program data
     /// ...
-    /// Discriminator (1)
+    /// Discriminator (2)
     pub discriminator: u8
     /// Extensions data
     /// ...
 }
 ```
 
-To maintain the legacy struct, the discriminator doesn't live in the first byte like usual, but lives at byte `165`.
+To maintain the legacy struct, the discriminator doesn't live in the first byte like usual, but lives at byte `166`.
 
-This is because the `Token` account length is 164 bytes, meaning that the discriminator gets added after the base length. For the `Mint` account, this means we had to add 83 bytes of padding to ensure that the two accounts have the same base length.
+This is because the `Token` account length is 165 bytes, meaning that the discriminator gets added after the base length. For the `Mint` account, this means we had to add 83 bytes of padding to ensure that the two accounts have the same base length.
 
-So to discriminate between the two accounts, we just need to check the 165th byte and move accordingly.
+So to discriminate between the two accounts, we just need to check the 166th byte (data[165] if you count from 0) and move accordingly.
 
 <ArticleSection name="Token Extensions" id="token-extensions" level="h2" />
 


### PR DESCRIPTION
Token account length is 165 bytes. Account type is in byte 166. Also account type for `Mint` is 1 and for `Token` is 2