### PR TITLE
feat:  add T22 warning to Anchor Escrow  #27

### DIFF
--- a/src/app/content/challenges/anchor-escrow/en/pages/make.mdx
+++ b/src/app/content/challenges/anchor-escrow/en/pages/make.mdx
@@ -137,3 +137,12 @@ pub fn handler(ctx: Context<Make>, seed: u64, receive: u64, amount: u64) -> Resu
 </Codeblock>
 
 Here we add two validation checks; one on the `amount` and one on the `receive` arguments to ensure we're not passing a zero value for either.
+
+### Warning
+
+Certain extensions from SPL Token-2022 e.g., transfer hooks, confidential transfers, default account states can introduce vulnerabilities like blocking transfers , locking funds and causing rug pulls in escrow logic, vaults, or CPIs.
+
+
+- Ensure `mint_a` and `mint_b` are owned by the same token program to prevent CPI failures.
+- Use well-audited tokens (e.g., USDC, wSOL) from the standard SPL Token program.
+- Avoid unverified or complex Token-2022 mints.


### PR DESCRIPTION
Added warning about SPL Token-2022 risks in escrow logic.

Content :
### Warning

Certain extensions from SPL Token-2022 e.g., transfer hooks, confidential transfers, default account states can introduce vulnerabilities like blocking transfers , locking funds and causing rug pulls in escrow logic, vaults, or CPIs.


- Ensure `mint_a` and `mint_b` are owned by the same token program to prevent CPI failures.
- Use well-audited tokens (e.g., USDC, wSOL) from the standard SPL Token program.
- Avoid unverified or complex Token-2022 mints. 

reference : https://www.solana-program.com/docs/token-2022/extensions#example-creating-a-mint-with-default-frozen-accounts .
