### PR TITLE
some minor grammar and account name mismatch

### DIFF
--- a/src/app/content/courses/program-security/introduction/en.mdx
+++ b/src/app/content/courses/program-security/introduction/en.mdx
@@ -12,7 +12,7 @@ While Ethereum developers worry about gas optimization and sequential execution,
 
 There are a lot of security exploits unique to Solana blockchain development. In this course you'll learn all Sealevel Attacks that are modeled on [Coral's Sealevel Attack repository](https://github.com/coral-xyz/sealevel-attacks), incorporating real-world examples and practical mitigation strategies.
 
-Before deploying your programs to Mainnet you should at least a basic understanding of security fundamentals.
+Before deploying your programs to Mainnet you should have at least a basic understanding of security fundamentals.
 
 > The same exploits are "valid" for both Native and Anchor development
 
@@ -26,7 +26,7 @@ The stateless nature of programs means that all validation logic must be explici
 
 Additionally, common vulnerability patterns in Solana programs include missing ownership checks, insufficient signer verification, arithmetic overflow/underflow, and improper handling of account initialization and closure. 
 
-> Anchor was developed with the idea of making Solana programs more secure by forcing developer to use specific types or do deliberate choices for their programs.
+> Anchor was developed with the idea of making Solana programs more secure by forcing developers to use specific types or do deliberate choices for their programs.
 
 Even though each security vulnerability may seem "simple" at first glance, there's substantial depth to discuss in each scenario. These lessons contain less prose and more practical code examples, ensuring you gain a solid, hands-on understanding of the security risks discussed.
 

--- a/src/app/content/courses/program-security/owner-checks/en.mdx
+++ b/src/app/content/courses/program-security/owner-checks/en.mdx
@@ -86,11 +86,11 @@ pub struct Instruction<'info> {
 }
 ```
 
-Or you could just add a owner check in the instruction using the `ctx.accounts.program_account.owner` check like this:
+Or you could just add an owner check in the instruction using the `ctx.accounts.program_account.owner` check like this:
 
 ```rust
 pub fn update_ownership(ctx: Context<UpdateOwnership>) -> Result<()> {
-    if ctx.accounts.program.owner != ID {
+    if ctx.accounts.program_account.owner != ID {
         return Err(ProgramError::IncorrectProgramId.into());
     }
     

--- a/src/app/content/courses/program-security/signer-checks/en.mdx
+++ b/src/app/content/courses/program-security/signer-checks/en.mdx
@@ -115,7 +115,7 @@ By adding this check, the instruction handler will only proceed if the authority
 
 In Pinocchio, since we don't have the possibility of adding security checks directly inside of the account struct, we are forced to do so in the instruction logic. 
 
-We can do so very similarly to anchor by using the `is_signer()` function like this:
+We can do so very similarly to Anchor by using the `is_signer()` function like this:
 
 ```rust
 if !self.accounts.owner.is_signer() {


### PR DESCRIPTION
Program Security Course


Owner check - uses if ctx.accounts.program.owner != ID but should be if ctx.accounts.program_account.owner != ID 

Simple grammar issues I noticed in Introduction and Signer checks

