### PR TITLE
fix: typo and incorrect discriminator example [program-security]

### DIFF
--- a/src/app/content/courses/program-security/arbitrary-cpi/en.mdx
+++ b/src/app/content/courses/program-security/arbitrary-cpi/en.mdx
@@ -65,7 +65,7 @@ An attacker can exploit this by:
 
 The attack succeeds because while the token accounts are legitimate, the program performing the operation is not. The malicious program might transfer tokens in the wrong direction, drain accounts to the attacker's wallet, or perform any operation that the passed accounts allow.
 
-Luckily `Anchor` makes it super easy to perform this check directly in the account struct by just changing `UncheckedAccount` to `Program` which automatically validates the program ID:
+Luckily `Anchor` makes it super easy to perform this check directly in the account struct by just changing `UncheckedAccount` to `Program` and passing the `Token` type which automatically validates the program ID:
 
 ```rust
 #[derive(Accounts)]

--- a/src/app/content/courses/program-security/data-matching/en.mdx
+++ b/src/app/content/courses/program-security/data-matching/en.mdx
@@ -53,7 +53,7 @@ An attacker can exploit this by:
 
 The transaction succeeds because `attacker_keypair` properly signs it, but the program never checks whether `attacker_keypair` matches the actual `owner` stored in `program_account.owner`. The attacker successfully transfers ownership of someone else's account to themselves.
 
-Luckily `Anchor` makes it super easy to perform this check directly in the account struct by adding the `has_one` constrain like this:
+Luckily `Anchor` makes it super easy to perform this check directly in the account struct by adding the `has_one` constraint like this:
 
 ```rust
 #[derive(Accounts)]
@@ -66,7 +66,7 @@ pub struct UpdateOwnership<'info> {
 }
 ```
 
-Or we could decide to change the desing of the program and make the `program_account` a PDA derived from the `owner` like this:
+Or we could decide to change the design of the program and make the `program_account` a PDA derived from the `owner` like this:
 
 ```rust
 #[derive(Accounts)]
@@ -115,7 +115,7 @@ if account_state.owner != self.accounts.owner.key() {
 }
 ```
 
-> You'll need to create your `ProgramAccount::try_deserialize()` function since Pinocchio lets us handle deserialization and serialization like we wish 
+> You'll need to create your `ProgramAccount::try_deserialize()` function since Pinocchio lets us handle deserialization and serialization as we wish 
 
 
 

--- a/src/app/content/courses/program-security/owner-checks/en.mdx
+++ b/src/app/content/courses/program-security/owner-checks/en.mdx
@@ -1,6 +1,6 @@
 import { ArticleSection } from "../../../../components/ArticleSection/ArticleSection";
 
-# Owner checks
+# Owner Checks
 
 Owner checks are the first line of defense in Solana program security. They verify that an account passed into an instruction handler is actually owned by the expected program, preventing attackers from substituting malicious lookalike accounts.
 

--- a/src/app/content/courses/program-security/reinitialization-attacks/en.mdx
+++ b/src/app/content/courses/program-security/reinitialization-attacks/en.mdx
@@ -1,6 +1,6 @@
 import { ArticleSection } from "../../../../components/ArticleSection/ArticleSection";
 
-# Reinitialization attacks
+# Reinitialization Attacks
 
 Reinitialization attacks exploit programs that fail to check whether an account has already been initialized, allowing attackers to overwrite existing data and hijack control of valuable accounts. 
 

--- a/src/app/content/courses/program-security/revival-attacks/en.mdx
+++ b/src/app/content/courses/program-security/revival-attacks/en.mdx
@@ -1,6 +1,6 @@
 import { ArticleSection } from "../../../../components/ArticleSection/ArticleSection";
 
-# Revival Attack
+# Revival Attacks
 
 Revival attacks exploit Solana's account closure mechanism by bringing "dead" accounts back to life within the same transaction. 
 

--- a/src/app/content/courses/program-security/revival-attacks/en.mdx
+++ b/src/app/content/courses/program-security/revival-attacks/en.mdx
@@ -65,6 +65,7 @@ The safest solution is using Anchor's `close` constraint, which handles secure c
 ```rust
 #[derive(Accounts)]
 pub struct Close<'info> {
+    #[account(mut)]
     pub owner: Signer<'info>,
    #[account(
         mut,

--- a/src/app/content/courses/program-security/signer-checks/en.mdx
+++ b/src/app/content/courses/program-security/signer-checks/en.mdx
@@ -1,6 +1,6 @@
 import { ArticleSection } from "../../../../components/ArticleSection/ArticleSection";
 
-# Signer checks
+# Signer Checks
 
 Signer checks are the digital equivalent of requiring a handwritten signature, they prove that an account holder actually authorized a transaction rather than someone else acting on their behalf. In Solana's trustless environment, this cryptographic proof is the only way to verify authentic authorization.
 

--- a/src/app/content/courses/program-security/type-cosplay/en.mdx
+++ b/src/app/content/courses/program-security/type-cosplay/en.mdx
@@ -69,7 +69,7 @@ An attacker can exploit this by:
 - The attacker becomes the "admin" for operations intended only for `ProgramAccountOne` owners
 
 Solana uses discriminators to solve this problem:
-- Anchor's 8-byte discriminator (default): Derived from the account name, automatically added to accounts marked with #[account]. (from anchor `0.31.0` it's possible to implement "custom" discriminator)
+- Anchor's 8-byte discriminator (default): Derived from the account name, automatically added to accounts marked with #[account]. (from anchor `0.31.0` it's possible to implement "custom" discriminators)
 - Length-based discrimination: Used by the Token Program to distinguish between Token and Mint accounts (though Token2022 now uses explicit discriminators)
 
 The simplest fix is using Anchor's built-in type validation:

--- a/src/app/content/courses/program-security/type-cosplay/en.mdx
+++ b/src/app/content/courses/program-security/type-cosplay/en.mdx
@@ -19,12 +19,11 @@ pub mod insecure_check{
     //..
 
     pub fn instruction(ctx: Context<Instruction>) -> Result<()> {
-        let account_data =
-            ProgramAccountOne::try_from_slice(&ctx.accounts.program_account_one.data.borrow()).unwrap();
-        if ctx.accounts.program_account_one.owner != ctx.program_id {
+        let program_account_one = ctx.accounts.program_account_one.to_account_info();
+        if program_account_one.owner != ctx.program_id {
             return Err(ProgramError::IllegalOwner.into());
         }
-        if account_data.owner != ctx.accounts.admin.key() {
+        if ctx.accounts.program_account_one.owner != ctx.accounts.admin.key() {
             return Err(ProgramError::InvalidAccountData.into());
         }
 
@@ -103,15 +102,17 @@ Or for custom validation, you can add explicit discriminator checks:
 
 ```rust
 pub fn instruction(ctx: Context<Instruction>) -> Result<()> {
-    let account_data =
-        ProgramAccountOne::try_from_slice(&ctx.accounts.program_account_one.data.borrow()).unwrap();
-    if ctx.accounts.program_account_one.owner != ctx.program_id {
+    let program_account_one = ctx.accounts.program_account_one.to_account_info();
+    if program_account_one.owner != ctx.program_id {
         return Err(ProgramError::IllegalOwner.into());
     }
-    if account_data.owner != ctx.accounts.admin.key() {
+    if ctx.accounts.program_account_one.owner != ctx.accounts.admin.key() {
         return Err(ProgramError::InvalidAccountData.into());
     }
-    if account_data.discriminant != AccountDiscriminant::ProgramAccountOne {
+    let data = program_account_one.data.borrow();
+    // Assume ProgramAccountOne has a discriminator of 8 bytes
+    let discriminator = &data[..8];
+    if discriminator != ProgramAccountOne::DISCRIMINATOR {
         return Err(ProgramError::InvalidAccountData.into());
     }
 


### PR DESCRIPTION
The example provided to verify matching discriminators doesn't actually work. Here's my take on it. Feedbacks are welcomed!