### PR TITLE
feat: implement i18n for NotFound page buttons and simplify non-chall…

### DIFF
--- a/messages/en/core.json
+++ b/messages/en/core.json
@@ -115,6 +115,8 @@
     "connect_wallet": "Connect Wallet",
     "connect_wallet_description": "A Solana wallet is required to complete the challenge and unlock NFTs",
     "back_to_lessons": "Back to Lessons",
+    "back_to_homepage": "Back to Homepage",
+    "head_to_challenges": "Back to Challenges", 
     "requirements_title": "Challenge",
     "upload_program_btn": "Upload Program",
     "run_program_btn": "Execute",

--- a/src/app/[locale]/not-found.tsx
+++ b/src/app/[locale]/not-found.tsx
@@ -2,42 +2,39 @@
 import { Link } from "@/i18n/navigation";
 import Button from "../components/Button/Button";
 import { usePathname } from "next/navigation";
+import { useTranslations } from "next-intl";
 
 export default function NotFound() {
   const pathname = usePathname();
+  const t = useTranslations();
 
   const isChallengesRoute = pathname.includes("/challenges");
   const isCoursesRoute = pathname.includes("/courses");
-
+  
   // Set appropriate content based on the route
   let message: string;
   let buttons: React.ReactNode;
-
+  
   if (isChallengesRoute) {
     message = "The challenge you are looking for doesn't exist.";
     buttons = (
       <Link href="/challenges">
-        <Button icon="ArrowLeft" label="Head to Challenges" />
+        <Button icon="ArrowLeft" label={t("ChallengePage.head_to_challenges")} />
       </Link>
     );
   } else if (isCoursesRoute) {
     message = "The course or lesson you are looking for doesn't exist.";
     buttons = (
       <Link href="/">
-        <Button icon="ArrowLeft" label="Head to Courses" />
+        <Button icon="ArrowLeft" label={t("ChallengePage.back_to_lessons")} />
       </Link>
     );
   } else {
     message = "The page you are looking for doesn't exist.";
     buttons = (
-      <div className="flex flex-col sm:flex-row gap-4">
-        <Link href="/">
-          <Button icon="ArrowLeft" label="Head to Courses" />
-        </Link>
-        <Link href="/challenges">
-          <Button icon="ArrowLeft" label="Head to Challenges" />
-        </Link>
-      </div>
+      <Link href="/">
+        <Button icon="ArrowLeft" label={t("ChallengePage.back_to_homepage")} />
+      </Link>
     );
   }
 


### PR DESCRIPTION
- Add i18n support for all NotFound page button labels using useTranslations hook
- Simplify non-challenge 404 page to show single "Back to Homepage" button redirecting to /
- Add translation keys: back_to_homepage, head_to_challenges in core.json
<img width="1439" height="764" alt="Screenshot 2025-08-01 at 8 18 19 PM" src="https://github.com/user-attachments/assets/2aad3e84-d698-4ee6-b366-7f865096f199" />
