### PR TITLE
fixes typo

### DIFF
--- a/src/app/content/courses/testing-with-mollusk/mollusk-101/en.mdx
+++ b/src/app/content/courses/testing-with-mollusk/mollusk-101/en.mdx
@@ -136,7 +136,7 @@ let program_account = Pubkey::new_unique();
 let program_account_account = Account {
     lamports,
     data,
-    owner: &ID, // The program's that owns the account
+    owner: ID, // The program's that owns the account
     executable: false,
     rent_epoch: 0,
 };


### PR DESCRIPTION
<img width="839" height="420" alt="Screenshot 2025-08-01 220424" src="https://github.com/user-attachments/assets/70213510-0028-4216-862e-0adbec75bb56" />

removes "&" : )