### PR TITLE
Remove message about pinocchio

### DIFF
--- a/src/app/content/courses/introduction-to-pinocchio/reading-and-writing-data/en.mdx
+++ b/src/app/content/courses/introduction-to-pinocchio/reading-and-writing-data/en.mdx
@@ -493,9 +493,7 @@ This is ideal because:
 
 <ArticleSection name="Dynamically Sized Data" id="dynamically-sized-data" level="h2" />
 
-Whenever possible, avoid storing dynamically sized data directly in accounts. However, some use cases require it. 
-
-> In Pinocchio, handling dynamic data is more challenging than in Anchor or standard Rust, primarily due to the `no_std` environment, which prevents us from using heap-allocated types like `Vec` or `String`.
+Whenever possible, avoid storing dynamically sized data directly in accounts. However, some use cases require it.
 
 If your account contains dynamic data, always place all statically sized fields at the beginning of your struct, and append the dynamic data at the end.
 


### PR DESCRIPTION
### Problem

The section about dynamic data currently shows a message about being more challenging to work with `Vec` and `String` types when using pinocchio due to it being a `no_std` crate. The message is not accurate since the fact that pinocchio is a `no_std` crate does not affect the program.

For a program to be `no_std`, it will have to explicitly declare its crate to be `no_std`.

### Solution

Remove the message since there are no differences in working with dynamic data when using pinocchio.