### PR TITLE
fix: mollusk-101 program accounts exec flag

### DIFF
--- a/src/app/content/courses/testing-with-mollusk/mollusk-101/en.mdx
+++ b/src/app/content/courses/testing-with-mollusk/mollusk-101/en.mdx
@@ -137,7 +137,7 @@ let program_account_account = Account {
     lamports,
     data,
     owner: ID, // The program's that owns the account
-    executable: false,
+    executable: true,
     rent_epoch: 0,
 };
 ```


### PR DESCRIPTION
Example on how to create `ProgramAccounts` in Mollusk has `executable` flag set to `false` instead of `true`.

e.g.
```
use solana_sdk::account::Account;
 
let data = vec![
    // Your serialized account data
];
let lamports = mollusk
    .sysvars
    .rent
    .minimum_balance(data.len());
 
let program_account = Pubkey::new_unique();
let program_account_account = Account {
    lamports,
    data,
    owner: ID, // The program's that owns the account
    executable: false, <<< SHOULD BE TRUE
    rent_epoch: 0,
};
```