### PR TITLE
Fix filter empty state when deselecting all items

### DIFF
--- a/src/app/components/ChallengeCenterContent/ChallengesList.tsx
+++ b/src/app/components/ChallengeCenterContent/ChallengesList.tsx
@@ -81,6 +81,7 @@ export default function ChallengesList({
   const filteredChallenges = useMemo(
     () =>
       initialChallenges.filter((challenge) =>
+        selectedChallengeStatus.length === 0 ||
         selectedChallengeStatus.includes(challengeStatuses[challenge.slug]),
       ),
     [initialChallenges, selectedChallengeStatus, challengeStatuses],
@@ -117,9 +118,7 @@ export default function ChallengesList({
         challengeLanguage={selectedChallenge.language}
         challengeDifficulty={selectedChallenge.difficulty}
       />
-      {hasNoFilters ? (
-        <ChallengesEmpty />
-      ) : hasNoResults ? (
+      {hasNoResults && !hasNoFilters ? (
         <ChallengesEmpty />
       ) : (
         <>

--- a/src/app/components/CoursesContent/CourseList.tsx
+++ b/src/app/components/CoursesContent/CourseList.tsx
@@ -103,9 +103,7 @@ export default function CourseList({
 
   const hasNoResults = filteredCourses.length === 0;
   const hasNoFilters = !searchValue && selectedLanguages.length === 0;
-  const showGetStarted =
-    hasNoFilters ||
-    selectedLanguages.length === Object.keys(courseSections).length;
+  const showGetStarted = hasNoFilters;
 
   // Helper function to get the current lesson slug
   const getCurrentLessonSlug = (courseSlug: string) => {
@@ -143,9 +141,7 @@ export default function CourseList({
       animate={{ opacity: 1 }}
       transition={{ duration: 0.4, ease: anticipate }}
     >
-      {hasNoFilters ? (
-        <CoursesEmpty type="no_filters" />
-      ) : hasNoResults ? (
+      {hasNoResults && !hasNoFilters ? (
         <CoursesEmpty type="no_results" />
       ) : (
         <>

--- a/src/app/components/Filters/ChallengeFilter.tsx
+++ b/src/app/components/Filters/ChallengeFilter.tsx
@@ -23,15 +23,15 @@ export default function ChallengeFilter({ className }: FiltersProps) {
 
   const allStatuses: ReadonlyArray<ChallengeStatus> = challengeStatus;
   const displayText =
-    selectedChallengeStatus.length === allStatuses.length
+    selectedChallengeStatus.length === 0 || selectedChallengeStatus.length === allStatuses.length
       ? t("ChallengeCenter.filter__label")
       : selectedChallengeStatus.length === 1
         ? selectedChallengeStatus[0]
         : `${selectedChallengeStatus.length} ${t("ChallengeCenter.filter__selected_statuses")}`;
 
   const toggleAllStatuses = () => {
-    if (selectedChallengeStatus.length === allStatuses.length) {
-      // If all are selected, deselect all
+    if (selectedChallengeStatus.length === 0 || selectedChallengeStatus.length === allStatuses.length) {
+      // If all are selected or none selected, deselect all
       allStatuses.forEach((status) => {
         if (selectedChallengeStatus.includes(status)) {
           toggleChallengeStatus(status);
@@ -48,8 +48,8 @@ export default function ChallengeFilter({ className }: FiltersProps) {
   };
 
   const handleStatusClick = (status: ChallengeStatus) => {
-    if (selectedChallengeStatus.length === allStatuses.length) {
-      // If "All" is selected, deselect all and select only the clicked status
+    if (selectedChallengeStatus.length === 0 || selectedChallengeStatus.length === allStatuses.length) {
+      // If "All" is selected or none selected, deselect all and select only the clicked status
       allStatuses.forEach((s) => {
         if (selectedChallengeStatus.includes(s)) {
           toggleChallengeStatus(s);
@@ -96,7 +96,7 @@ export default function ChallengeFilter({ className }: FiltersProps) {
               className="flex items-center gap-x-4 py-3 px-2.5 pr-4 rounded-lg transition hover:bg-background-card-foreground"
             >
               <Checkbox
-                checked={selectedChallengeStatus.length === allStatuses.length}
+                checked={selectedChallengeStatus.length === 0 || selectedChallengeStatus.length === allStatuses.length}
               />
               <span className="text-sm font-medium leading-none text-secondary">
                 {t("ChallengeCenter.filter__all_statuses")}

--- a/src/app/components/Filters/CourseFilter.tsx
+++ b/src/app/components/Filters/CourseFilter.tsx
@@ -25,15 +25,15 @@ export default function CourseFilter({ className }: FiltersProps) {
 
   const allLanguages = Object.keys(courseLanguages) as CourseLanguages[];
   const displayText =
-    selectedLanguages.length === allLanguages.length
+    selectedLanguages.length === 0 || selectedLanguages.length === allLanguages.length
       ? t("ui.search_language_filter__label")
       : selectedLanguages.length === 1
         ? selectedLanguages[0]
         : `${selectedLanguages.length} ${t("ui.search_language_filter__selected_languages")}`;
 
   const toggleAllLanguages = () => {
-    if (selectedLanguages.length === allLanguages.length) {
-      // If all are selected, deselect all
+    if (selectedLanguages.length === 0 || selectedLanguages.length === allLanguages.length) {
+      // If all are selected or none selected, deselect all
       allLanguages.forEach((lang) => {
         if (selectedLanguages.includes(lang)) {
           toggleLanguage(lang);
@@ -50,8 +50,8 @@ export default function CourseFilter({ className }: FiltersProps) {
   };
 
   const handleLanguageClick = (language: CourseLanguages) => {
-    if (selectedLanguages.length === allLanguages.length) {
-      // If "All" is selected, deselect all and select only the clicked language
+    if (selectedLanguages.length === 0 || selectedLanguages.length === allLanguages.length) {
+      // If "All" is selected or none selected, deselect all and select only the clicked language
       allLanguages.forEach((lang) => {
         if (selectedLanguages.includes(lang)) {
           toggleLanguage(lang);
@@ -98,7 +98,7 @@ export default function CourseFilter({ className }: FiltersProps) {
               className="flex items-center gap-x-4 py-3 px-2.5 pr-4 rounded-lg transition hover:bg-background-card-foreground"
             >
               <Checkbox
-                checked={selectedLanguages.length === allLanguages.length}
+                checked={selectedLanguages.length === 0 || selectedLanguages.length === allLanguages.length}
               />
               <span className="text-sm font-medium leading-none text-secondary">
                 {t("ui.search_language_filter__all_languages")}


### PR DESCRIPTION
Fixes an issue where deselecting all individual filter items would show an empty state instead of displaying all available content. 

**Previously:**
- Select "Rust" → shows Rust content ✅
- Deselect "Rust" → shows empty "no filters selected" state ❌
<img width="1435" height="781" alt="initial_challenges" src="https://github.com/user-attachments/assets/d8b40f66-ad8f-4038-8609-6a1a9d112b90" />

**Now:**
- Select "Rust" → shows Rust content ✅  
- Deselect "Rust" → shows all available content ✅

**Changes:**
- Modified CourseList.tsx to only show empty state when filters are applied but no results found
- Applied same fix to ChallengesList.tsx for consistency
- Maintains proper "no results" state when specific filters yield no matches