### PR TITLE
Correctly locate the test program to load

### DIFF
--- a/src/app/content/courses/testing-with-mollusk/mollusk-101/en.mdx
+++ b/src/app/content/courses/testing-with-mollusk/mollusk-101/en.mdx
@@ -77,10 +77,12 @@ const ID: Pubkey = solana_sdk::pubkey!("2222222222222222222222222222222222222222
 
 #[test]
 fn test() {
-    let mollusk = Mollusk::new(&ID, "target/deploy/program.so");
+    // Omit the `.so` file extension for the program name since
+    // it is automatically added when Mollusk is loading the file.
+    let mollusk = Mollusk::new(&ID, "target/deploy/program");
     
     // Alternative using an Array of bytes
-    // let mollusk = Mollusk::new(&Pubkey::new_from_array(ID), "target/deploy/program.so")
+    // let mollusk = Mollusk::new(&Pubkey::new_from_array(ID), "target/deploy/program")
 }
 ```
 

--- a/src/app/content/courses/testing-with-mollusk/mollusk-101/fr.mdx
+++ b/src/app/content/courses/testing-with-mollusk/mollusk-101/fr.mdx
@@ -77,10 +77,10 @@ const ID: Pubkey = solana_sdk::pubkey!("2222222222222222222222222222222222222222
 
 #[test]
 fn test() {
-    let mollusk = Mollusk::new(&ID, "target/deploy/program.so");
+    let mollusk = Mollusk::new(&ID, "target/deploy/program");
     
     // Alternative using an Array of bytes
-    // let mollusk = Mollusk::new(&Pubkey::new_from_array(ID), "target/deploy/program.so")
+    // let mollusk = Mollusk::new(&Pubkey::new_from_array(ID), "target/deploy/program")
 }
 ```
 
@@ -281,7 +281,6 @@ mollusk.process_and_validate_instruction_chain(&[
     ]),
 ]);
 ```
-
 
 
 


### PR DESCRIPTION
A fix for locating the correct `program.so` file has been added. Currently the course loads the program using `Mollusk::new(&ID, "target/deploy/program.so")` causing testing to crash. This is because mollusk-svm adds the `.so` file extension in the within the `load_program_elf` function:

https://github.com/anza-xyz/mollusk/blob/e50cf9fbc69b92f347978bb5528192d90d8a88a3/harness/src/file.rs#L81

the fix for this is removing the `.so` in the `Mollusk::new(&ID, "target/deploy/program)` code

Closes #136