### PR TITLE
Use dev cargo args in mollusk course

### DIFF
--- a/src/app/content/courses/testing-with-mollusk/mollusk-101/en.mdx
+++ b/src/app/content/courses/testing-with-mollusk/mollusk-101/en.mdx
@@ -30,32 +30,30 @@ The core `mollusk-svm` crate provides the fundamental testing infrastructure, wh
 Add the main Mollusk crate to your project:
 
 ```
-cargo add mollusk-svm
+cargo add mollusk-svm --dev
 ```
 
 Include program-specific helpers as needed:
 
 ```
-cargo add mollusk-svm-programs-memo mollusk-svm-programs-token
+cargo add mollusk-svm-programs-memo mollusk-svm-programs-token --dev
 ```
 
 These additional crates provide pre-configured helpers for standard Solana programs, reducing boilerplate code and simplifying the setup of common testing scenarios involving token operations or memo instructions.
+
+> The `--dev` flag in `cargo add <crate-name> --dev` is used to  keep your program binary lightweight by adding them under the `[dev-dependencies]` section in your `Cargo.toml`
+> This configuration ensures that testing utilities don't increase your program's deployment size while providing access to all necessary Solana types and helper functions during development.
+
 
 ### Additional Dependencies
 
 Several Solana crates enhance the testing experience by providing essential types and utilities:
 
 ```
-cargo add solana-precompiles solana-account solana-pubkey solana-feature-set solana-program solana-sdk
+cargo add solana-precompiles solana-account solana-pubkey solana-feature-set solana-program solana-sdk --dev
 ```
 
-Since these dependencies are only needed for testing, keep your program binary lightweight by adding them under the `[dev-dependencies]` section in your `Cargo.toml`:
 
-```
-[dev-dependencies]
-mollusk-svm = "0.4.0"
-```
-> This configuration ensures that testing utilities don't increase your program's deployment size while providing access to all necessary Solana types and helper functions during development.
 
 <ArticleSection name="Mollusk Basics" id="mollusk-basics" level="h2" />
 

--- a/src/app/content/courses/testing-with-mollusk/mollusk-101/en.mdx
+++ b/src/app/content/courses/testing-with-mollusk/mollusk-101/en.mdx
@@ -77,10 +77,12 @@ const ID: Pubkey = solana_sdk::pubkey!("2222222222222222222222222222222222222222
 
 #[test]
 fn test() {
-    let mollusk = Mollusk::new(&ID, "target/deploy/program.so");
+    // Omit the `.so` file extension for the program name since
+    // it is automatically added when Mollusk is loading the file.
+    let mollusk = Mollusk::new(&ID, "target/deploy/program");
     
     // Alternative using an Array of bytes
-    // let mollusk = Mollusk::new(&Pubkey::new_from_array(ID), "target/deploy/program.so")
+    // let mollusk = Mollusk::new(&Pubkey::new_from_array(ID), "target/deploy/program")
 }
 ```
 

--- a/src/app/content/courses/testing-with-mollusk/mollusk-101/fr.mdx
+++ b/src/app/content/courses/testing-with-mollusk/mollusk-101/fr.mdx
@@ -30,32 +30,27 @@ La crate principale `mollusk-svm` fournit l'infrastructure de test fondamentale 
 Ajoutez la crate principale Mollusk à votre projet :
 
 ```
-cargo add mollusk-svm
+cargo add mollusk-svm  --dev
 ```
 
 Ajoutez des fonctions d'aides spécifiques au programme si nécessaire :
 
 ```
-cargo add mollusk-svm-programs-memo mollusk-svm-programs-token
+cargo add mollusk-svm-programs-memo mollusk-svm-programs-token  --dev
 ```
 
 Ces crates supplémentaires fournissent des fonctions d'aides préconfigurées pour les programmes Solana standard, réduisant ainsi le code passe-partout et simplifiant la configuration des scénarios de test courants impliquant des opérations de jetons ou des instructions mémo.
+
+> L'option `--dev` dans `cargo add <crate-name> --dev` permet de conserver la légèreté des binaires de votre programme en les ajoutant sous la section `[dev-dependencies]` de votre fichier `Cargo.toml`
+> Cette configuration garantit que les utilitaires de test n'augmentent pas la taille de déploiement de votre programme tout en donnant accès à tous les types Solana et fonctions d'assistance nécessaires pendant le développement.
 
 ### Dépendances Supplémentaires
 
 Plusieurs crates Solana améliorent l'expérience de test en fournissant des types et des utilitaires essentiels :
 
 ```
-cargo add solana-precompiles solana-account solana-pubkey solana-feature-set solana-program solana-sdk
+cargo add solana-precompiles solana-account solana-pubkey solana-feature-set solana-program solana-sdk  --dev
 ```
-
-Comme ces dépendances ne sont nécessaires que pour les tests, veillez à ce que votre fichier binaire reste léger en les ajoutant dans la section `[dev-dependencies]` de votre fichier `Cargo.toml` :
-
-```
-[dev-dependencies]
-mollusk-svm = "0.4.0"
-```
-> Cette configuration garantit que les utilitaires de test n'augmentent pas la taille de déploiement de votre programme tout en fournissant l'accès à tous les types Solana et fonctions d'aide nécessaires pendant le développement.
 
 <ArticleSection name="Les Bases de Mollusk" id="mollusk-basics" level="h2" />
 

--- a/src/app/content/courses/testing-with-mollusk/mollusk-101/fr.mdx
+++ b/src/app/content/courses/testing-with-mollusk/mollusk-101/fr.mdx
@@ -77,10 +77,10 @@ const ID: Pubkey = solana_sdk::pubkey!("2222222222222222222222222222222222222222
 
 #[test]
 fn test() {
-    let mollusk = Mollusk::new(&ID, "target/deploy/program.so");
+    let mollusk = Mollusk::new(&ID, "target/deploy/program");
     
     // Alternative using an Array of bytes
-    // let mollusk = Mollusk::new(&Pubkey::new_from_array(ID), "target/deploy/program.so")
+    // let mollusk = Mollusk::new(&Pubkey::new_from_array(ID), "target/deploy/program")
 }
 ```
 
@@ -281,7 +281,6 @@ mollusk.process_and_validate_instruction_chain(&[
     ]),
 ]);
 ```
-
 
 
 


### PR DESCRIPTION

Avoid manually moving the dependencies to the dev-dependencies section
    
Mollusk introduction course manually requires devs to add dependencies
to the `dev-dependencies` section of their `Cargo.toml` file yet they
are already using `cargo add` to add dependencies.
    
This commit adds a `--dev` flag to each `cargo add <crate-name>` to automatically
add each dependency to the `dev` section of the manifest file.
    
 This add the information to the french course too
    
Depends on PR #137 since it incorporates a fix from that PR
Closes #138
