### PR TITLE
typo: removed extra comma.

### DIFF
--- a/src/app/content/courses/spl-token-with-anchor/close-account/en.mdx
+++ b/src/app/content/courses/spl-token-with-anchor/close-account/en.mdx
@@ -18,7 +18,7 @@ close_account(
         ctx.accounts.token_program.to_account_info(),
         CloseAccount {
             account: ctx.accounts.token_account.to_account_info(),
-            destination: ctx.accounts.authority.to_account_info(),,
+            destination: ctx.accounts.authority.to_account_info(),
             authority: ctx.accounts.authority.to_account_info(),
         },
     ),


### PR DESCRIPTION
removed extra comma which could've caused error in copy pasting the code