### PR TITLE
links and typo fixes

### DIFF
--- a/src/app/content/challenges/assembly-memo/en/challenge.mdx
+++ b/src/app/content/challenges/assembly-memo/en/challenge.mdx
@@ -13,7 +13,7 @@ If you're unfamiliar with assembly programming, follow the [introduction to Asse
 
 <ArticleSection name="Program Design" id="program-design" level="h2" />
 
-Our program will simply put the right memory location into the right registry and then perform the `sol_log_` syscall. It will look like this:
+Our program will simply put the right memory location into the right register and then perform the `sol_log_` syscall. It will look like this:
 
 <Codeblock lang="assembly">
 ```sbpf

--- a/src/app/content/challenges/assembly-memo/en/verify.mdx
+++ b/src/app/content/challenges/assembly-memo/en/verify.mdx
@@ -9,7 +9,7 @@ Create a program only has one instruction. It must:
 - Set `r2` to the length of the instruction data, and `r1` to the offset of the instruction data, 
 - Invoke the `sol_log_` syscall.
 
-Start by installing the sBPF package like explained in the [tooling section](en/courses/introduction-to-assembly/tooling) of the Introduction to Assembly course and build your program using the following command in your terminal:
+Start by installing the sBPF package like explained in the [tooling section](/en/courses/introduction-to-assembly/tooling) of the Introduction to Assembly course and build your program using the following command in your terminal:
 
 ```
 sbpf light-build

--- a/src/app/content/challenges/assembly-slippage/en/challenge.mdx
+++ b/src/app/content/challenges/assembly-slippage/en/challenge.mdx
@@ -35,7 +35,7 @@ sBPF programs receive account data as contiguous memory regions. These constants
 ```
 </Codeblock>
 
-- `TOKEN_ACCOUNT_BALANCE` (0x00a0): points to the balance field in SPL Token account data. Token accounts follow a standard layout where the balance (8 bytes, little-endian) sits at offset 160.
+- `TOKEN_ACCOUNT_BALANCE (0x00a0)`: points to the balance field in SPL Token account data. Token accounts follow a standard layout where the balance (8 bytes, little-endian) sits at offset 160.
 
 - `MINIMUM_BALANCE (0x2918)`: locates where Solana places your instruction data payload. This offset is part of the runtime's account info structure.
 

--- a/src/app/content/challenges/assembly-slippage/en/verify.mdx
+++ b/src/app/content/challenges/assembly-slippage/en/verify.mdx
@@ -14,7 +14,7 @@ Create a program only has one instruction. It must:
 
 > To get the right instruction data offset you can use our [tool](https://sbpf.xyz). But we're going to help you out: the `data_len` of the token account is at `.equ TOKEN_ACCOUNT_DATA_LEN, 0x0058`
 
-Start by installing the sBPF package like explained in the [tooling section](en/courses/introduction-to-assembly/tooling) of the Introduction to Assembly course and build your program using the following command in your terminal:
+Start by installing the sBPF package like explained in the [tooling section](/en/courses/introduction-to-assembly/tooling) of the Introduction to Assembly course and build your program using the following command in your terminal:
 
 ```
 sbpf build

--- a/src/app/content/challenges/assembly-timeout/en/verify.mdx
+++ b/src/app/content/challenges/assembly-timeout/en/verify.mdx
@@ -14,7 +14,7 @@ Create a program only has one instruction. It must:
 
 > To get the right instruction data offset you can use our [tool](https://sbpf.xyz). Just remember to add one account and set its data lenght as 40! 
 
-Start by installing the sBPF package like explained in the [tooling section](en/courses/introduction-to-assembly/tooling) of the Introduction to Assembly course and build your program using the following command in your terminal:
+Start by installing the sBPF package like explained in the [tooling section](/en/courses/introduction-to-assembly/tooling) of the Introduction to Assembly course and build your program using the following command in your terminal:
 
 ```
 sbpf build


### PR DESCRIPTION
Links on the verify pages to the tooling were broken and registry looked like a typo