### PR TITLE
Fix Anchor version guidance: use v0.31.0 or later

### DIFF
--- a/src/app/content/challenges/anchor-escrow/en/challenge.mdx
+++ b/src/app/content/challenges/anchor-escrow/en/challenge.mdx
@@ -107,7 +107,7 @@ pub mod blueshift_anchor_escrow {
 ```
 </Codeblock>
 
-As you see, we implemented custom discriminator for the instructions. So make sure to use an anchor version 0.31.0 or older.
+As you see, we implemented custom discriminator for the instructions. So make sure to use an anchor version 0.31.0 or newer.
 
 <ArticleSection name="State" id="state" level="h2" />
 


### PR DESCRIPTION
This updates the instruction "anchor v0.31.0 or older."  to “anchor v0.31.0 or newer.” 