### PR TITLE
Minor copy edits for clarity

### DIFF
--- a/src/app/content/challenges/anchor-escrow/en/pages/make.mdx
+++ b/src/app/content/challenges/anchor-escrow/en/pages/make.mdx
@@ -11,12 +11,12 @@ We can now move to the `make` instruction, that lives in the `make.rs` and will 
 ### Accounts 
 
 The accounts needed in this context are:
-- `maker`: the user that decides the terms and deposit the `mint_a` into the `Escrow`
-- `escrow`: the account where all the terms of this exchange lives
+- `maker`: the user that decides the terms and deposits the `mint_a` into the `Escrow`
+- `escrow`: the account holding the exchange terms (maker, mints, amounts)
 - `mint_a`: the token that the `maker` is depositing
 - `mint_b`: the token that the `maker` wants in exchange
-- `maker_ata_a`: the token account associated with the `maker` and `mint_a` used to the deposit tokens in the `vault`
-- `vault`: the token account associated with the `escrow` and `mint_a` where the tokens deposits gets parked
+- `maker_ata_a`: the token account associated with the `maker` and `mint_a` used to deposit tokens in the `vault`
+- `vault`: the token account associated with the `escrow` and `mint_a` where deposited tokens are parked
 - `associated_token_program`: the associated token program used to create the associated token accounts
 - `token_program`: the token program used to CPI the transfer
 - `system_program`: the system program used to create the `Escrow`
@@ -71,7 +71,7 @@ pub struct Make<'info> {
 ```
 </Codeblock>
 
-**Note**: Since we supply only one `token_program` to make sure that the CPI doesn't fail in the `take` instruction, where we perform transfer with both mint, we need to check that the two mint are owned by the same program.
+**Note**: This instruction passes a single token_program. Because take transfers for both mints, we must ensure both mints are owned by that same program (SPL Token or Token-2022), or the CPI will fail.
 
 ### Logic 
 


### PR DESCRIPTION
Small text-only edits in the Make section to improve clarity and grammar.
	•	Clarify the note about passing a single token_program.
	•	Fix a couple of minor phrasing/typo issues.