### PR TITLE
used helpers

### DIFF
--- a/src/app/content/courses/testing-with-mollusk/advanced-functionalities/en.mdx
+++ b/src/app/content/courses/testing-with-mollusk/advanced-functionalities/en.mdx
@@ -105,105 +105,82 @@ let (associated_token_program, associated_token_program_account) =
 
 These helpers ensure that token-related tests have access to the correct program accounts with proper configuration, enabling comprehensive testing of token operations without manual program setup.
 
-If we then wanted to create State accounts from the token program that are already initialized, we would need to create them using the Account method and load them in the account struct of the Mollusk instance.
+### Pre-initialized token state helpers
 
-Creating initialized token accounts manually involves significant boilerplate for serializing account data and calculating rent exemption. Here are helper functions that streamline this process:
+Use the official state helpers added in mollusk-svm-programs-token (PR #146) to create pre-initialized SPL Token state without issuing raw instructions.
+
+> Note: The example below uses `spl-token` types (`Mint`, `Account`), so add it as a dev-dependency: `cargo add spl-token --dev`.
 
 ```rust
-use spl_token::{state::{Mint, Account as TokenAccount, AccountState}, ID as token};
-use spl_associated_token_account::get_associated_token_address_with_program_id;
+use {
+    mollusk_svm::Mollusk,
+    solana_sdk::pubkey::Pubkey,
+    spl_token::state::{Mint, Account as TokenAccount, AccountState},
+};
 
-// Create a Keyed Account for a Mint with default data
-#[allow(dead_code)]
-pub fn keyed_account_for_mint_default(
-    mollusk: &Mollusk,
-    authority: &Pubkey,
-    decimals: u8,
-    pubkey: Option<Pubkey>,
-    token_program: Option<Pubkey>,
-) -> (Pubkey, Account) {
+#[test]
+fn test_preinitialized_token_state() {
+    let mut mollusk = Mollusk::default();
+
+    // Add SPL programs
+    mollusk_svm_programs_token::token::add_program(&mut mollusk);
+    mollusk_svm_programs_token::token2022::add_program(&mut mollusk);
+    mollusk_svm_programs_token::associated_token::add_program(&mut mollusk);
+
+    // Optional: program keyed accounts
+    let (_token_program, _token_program_account) =
+        mollusk_svm_programs_token::token::keyed_account();
+    let (_token2022_program, _token2022_program_account) =
+        mollusk_svm_programs_token::token2022::keyed_account();
+    let (_associated_token_program, _associated_token_program_account) =
+        mollusk_svm_programs_token::associated_token::keyed_account();
+
+    // Authorities and user
+    let mint_authority = Pubkey::new_unique();
+    let user = Pubkey::new_unique();
+
+    // Choose your mint address and pre-mint amount
+    let mint_pubkey = Pubkey::new_unique();
+    let decimals = 9u8;
+    let amount_to_mint: u64 = 1_000_000;
+
+    // 1) Create a pre-initialized Mint account
     let mint_data = Mint {
-        mint_authority: Some(*authority).into(),
-        supply: 0,
+        mint_authority: Some(mint_authority).into(),
+        supply: amount_to_mint, // reflect pre-minted supply
         decimals,
         is_initialized: true,
         freeze_authority: None.into(),
     };
+    let mint_account =
+        mollusk_svm_programs_token::token::create_account_for_mint(mint_data);
 
-    let mut data = vec![0u8; Mint::LEN];
-    Mint::pack(mint_data, &mut data).unwrap();
-
-    let account = Account {
-        lamports: mollusk.sysvars.rent.minimum_balance(Mint::LEN),
-        data,
-        owner: token_program.unwrap_or(token::ID),
-        executable: false,
-        rent_epoch: 0,
-    };
-
-    (pubkey.unwrap_or(Pubkey::new_unique()), account)
-}
-
-// Create a Keyed Account for a Token Account with default data
-#[allow(dead_code)]
-pub fn keyed_account_for_token_account_default(
-    mollusk: &Mollusk,
-    mint: &Pubkey,
-    owner: &Pubkey,
-    amount: u64,
-    pubkey: Option<Pubkey>,
-    token_program: Option<Pubkey>,
-) -> (Pubkey, Account) {
-    let account_data = TokenAccount {
-        mint: *mint,
-        owner: *owner,
-        amount,
+    // 2) Create a pre-initialized Associated Token Account (ATA) for the user
+    let ata_data = TokenAccount {
+        mint: mint_pubkey,
+        owner: user,
+        amount: amount_to_mint, // balance after a hypothetical mint_to
         delegate: None.into(),
         state: AccountState::Initialized,
         is_native: None.into(),
         delegated_amount: 0,
         close_authority: None.into(),
     };
+    let (ata_pubkey, ata_account) =
+        mollusk_svm_programs_token::associated_token::create_account_for_associated_token_account(ata_data);
 
-    let mut data = vec![0u8; TokenAccount::LEN];
-    TokenAccount::pack(account_data, &mut data).unwrap();
+    // 3) Provide these as input accounts to your instruction under test
+    let accounts = vec![
+        (mint_pubkey, mint_account),
+        (ata_pubkey, ata_account),
+    ];
 
-    let account = Account {
-        lamports: mollusk.sysvars.rent.minimum_balance(TokenAccount::LEN),
-        data,
-        owner: token_program.unwrap_or(token::ID),
-        executable: false,
-        rent_epoch: 0,
-    };
-
-    (pubkey.unwrap_or(Pubkey::new_unique()), account)
-}
-
-// Create a Keyed Account for an Associated Token Account with default data
-#[allow(dead_code)]
-pub fn keyed_account_for_associated_token_account_default(
-    mollusk: &Mollusk,
-    mint: &Pubkey,
-    owner: &Pubkey,
-    amount: u64,
-    token_program: Option<Pubkey>,
-) -> (Pubkey, Account) {
-    let associated_token_address = get_associated_token_address_with_program_id(
-        owner,
-        mint,
-        &token_program.unwrap_or(token::ID),
-    );
-
-    keyed_account_for_token_account_default(
-        mollusk,
-        mint,
-        owner,
-        amount,
-        Some(associated_token_address),
-        Some(token_program.unwrap_or(token::ID)),
-    )
+    // Now pass `accounts` to a Mollusk execution call alongside your instruction
+    // e.g. mollusk.process_and_validate_instruction(&instruction, &accounts, &[Check::success()]);
 }
 ```
+
+> With these helpers you avoid manual serialization, rent math, and address derivation. They create data-ready accounts you can drop straight into your Mollusk tests.
 
 <ArticleSection name="Benchmarking Compute Units" id="benchmarking-compute-units" level="h2" />
 

--- a/src/app/content/courses/testing-with-mollusk/advanced-functionalities/fr.mdx
+++ b/src/app/content/courses/testing-with-mollusk/advanced-functionalities/fr.mdx
@@ -105,105 +105,82 @@ let (associated_token_program, associated_token_program_account) =
 
 Ces aides garantissent que les tests liés aux jetons ont accès aux comptes de programme corrects avec une configuration appropriée, ce qui permet de tester de manière exhaustive les opérations liées aux jetons sans configuration manuelle du programme.
 
-Si nous voulions ensuite créer des comptes de `State` à partir du programme de jetons déjà initialisés, nous devrions les créer à l'aide de la méthode `Account` et les charger dans la structure de compte de l'instance Mollusk.
+### Assistants d'état pré-initialisé pour les jetons
 
-La création manuelle de comptes de jetons initialisés implique un travail fastidieux pour sérialiser les données des comptes et calculer l'exonération de rente. Voici des fonctions d'aide qui simplifient ce processus :
+Utilisez les fonctions d'aide officielles ajoutées dans mollusk-svm-programs-token (PR #146) pour créer de l'état SPL Token pré-initialisé sans émettre d'instructions brutes.
+
+> Remarque : L'exemple ci-dessous utilise les types `spl-token` (`Mint`, `Account`), ajoutez-le en dépendance de dev : `cargo add spl-token --dev`.
 
 ```rust
-use spl_token::{state::{Mint, Account as TokenAccount, AccountState}, ID as token};
-use spl_associated_token_account::get_associated_token_address_with_program_id;
+use {
+    mollusk_svm::Mollusk,
+    solana_sdk::pubkey::Pubkey,
+    spl_token::state::{Mint, Account as TokenAccount, AccountState},
+};
 
-// Create a Keyed Account for a Mint with default data
-#[allow(dead_code)]
-pub fn keyed_account_for_mint_default(
-    mollusk: &Mollusk,
-    authority: &Pubkey,
-    decimals: u8,
-    pubkey: Option<Pubkey>,
-    token_program: Option<Pubkey>,
-) -> (Pubkey, Account) {
+#[test]
+fn test_etat_token_preinitialise() {
+    let mut mollusk = Mollusk::default();
+
+    // Ajouter les programmes SPL
+    mollusk_svm_programs_token::token::add_program(&mut mollusk);
+    mollusk_svm_programs_token::token2022::add_program(&mut mollusk);
+    mollusk_svm_programs_token::associated_token::add_program(&mut mollusk);
+
+    // Facultatif : comptes clé du programme
+    let (_token_program, _token_program_account) =
+        mollusk_svm_programs_token::token::keyed_account();
+    let (_token2022_program, _token2022_program_account) =
+        mollusk_svm_programs_token::token2022::keyed_account();
+    let (_associated_token_program, _associated_token_program_account) =
+        mollusk_svm_programs_token::associated_token::keyed_account();
+
+    // Autorités et utilisateur
+    let mint_authority = Pubkey::new_unique();
+    let user = Pubkey::new_unique();
+
+    // Choisissez l'adresse du mint et le montant pré-minté
+    let mint_pubkey = Pubkey::new_unique();
+    let decimals = 9u8;
+    let amount_to_mint: u64 = 1_000_000;
+
+    // 1) Créer un compte Mint pré-initialisé
     let mint_data = Mint {
-        mint_authority: Some(*authority).into(),
-        supply: 0,
+        mint_authority: Some(mint_authority).into(),
+        supply: amount_to_mint, // reflète une supply déjà mintée
         decimals,
         is_initialized: true,
         freeze_authority: None.into(),
     };
+    let mint_account =
+        mollusk_svm_programs_token::token::create_account_for_mint(mint_data);
 
-    let mut data = vec![0u8; Mint::LEN];
-    Mint::pack(mint_data, &mut data).unwrap();
-
-    let account = Account {
-        lamports: mollusk.sysvars.rent.minimum_balance(Mint::LEN),
-        data,
-        owner: token_program.unwrap_or(token::ID),
-        executable: false,
-        rent_epoch: 0,
-    };
-
-    (pubkey.unwrap_or(Pubkey::new_unique()), account)
-}
-
-// Create a Keyed Account for a Token Account with default data
-#[allow(dead_code)]
-pub fn keyed_account_for_token_account_default(
-    mollusk: &Mollusk,
-    mint: &Pubkey,
-    owner: &Pubkey,
-    amount: u64,
-    pubkey: Option<Pubkey>,
-    token_program: Option<Pubkey>,
-) -> (Pubkey, Account) {
-    let account_data = TokenAccount {
-        mint: *mint,
-        owner: *owner,
-        amount,
+    // 2) Créer un compte Token associé (ATA) pré-initialisé pour l'utilisateur
+    let ata_data = TokenAccount {
+        mint: mint_pubkey,
+        owner: user,
+        amount: amount_to_mint, // solde après un mint_to hypothétique
         delegate: None.into(),
         state: AccountState::Initialized,
         is_native: None.into(),
         delegated_amount: 0,
         close_authority: None.into(),
     };
+    let (ata_pubkey, ata_account) =
+        mollusk_svm_programs_token::associated_token::create_account_for_associated_token_account(ata_data);
 
-    let mut data = vec![0u8; TokenAccount::LEN];
-    TokenAccount::pack(account_data, &mut data).unwrap();
+    // 3) Fournir ces comptes comme entrées à votre instruction sous test
+    let accounts = vec![
+        (mint_pubkey, mint_account),
+        (ata_pubkey, ata_account),
+    ];
 
-    let account = Account {
-        lamports: mollusk.sysvars.rent.minimum_balance(TokenAccount::LEN),
-        data,
-        owner: token_program.unwrap_or(token::ID),
-        executable: false,
-        rent_epoch: 0,
-    };
-
-    (pubkey.unwrap_or(Pubkey::new_unique()), account)
-}
-
-// Create a Keyed Account for an Associated Token Account with default data
-#[allow(dead_code)]
-pub fn keyed_account_for_associated_token_account_default(
-    mollusk: &Mollusk,
-    mint: &Pubkey,
-    owner: &Pubkey,
-    amount: u64,
-    token_program: Option<Pubkey>,
-) -> (Pubkey, Account) {
-    let associated_token_address = get_associated_token_address_with_program_id(
-        owner,
-        mint,
-        &token_program.unwrap_or(token::ID),
-    );
-
-    keyed_account_for_token_account_default(
-        mollusk,
-        mint,
-        owner,
-        amount,
-        Some(associated_token_address),
-        Some(token_program.unwrap_or(token::ID)),
-    )
+    // Passez maintenant `accounts` à un appel d'exécution Mollusk avec votre instruction
+    // ex. mollusk.process_and_validate_instruction(&instruction, &accounts, &[Check::success()]);
 }
 ```
+
+> Avec ces aides, vous évitez la sérialisation manuelle, le calcul de la rente et la dérivation d'adresse. Elles créent des comptes prêts à l'emploi que vous pouvez utiliser directement dans vos tests Mollusk.
 
 <ArticleSection name="Benchmark des Unités de Calcul" id="benchmarking-compute-units" level="h2" />
 
@@ -465,21 +442,6 @@ mollusk.set_feature_set(FeatureSet::default());
 Pour obtenir la liste complète des fonctionnalités disponibles, consultez la [documentation](https://docs.rs/agave-feature-set/2.3.6/agave_feature_set/) de la crate `agave-feature-set` qui détaille toutes les fonctionnalités configurables de la blockchain et leurs implications.
 
 Mollusk donne accès à toutes les variables système (sysvars) que les programmes peuvent interroger pendant leur exécution. Bien que ces paramètres soient automatiquement configurés avec des valeurs par défaut raisonnables, vous pouvez les personnaliser pour des scénarios de test précis :
-
-```rust
-/// Mollusk sysvars wrapper for easy manipulation
-pub struct Sysvars {
-    pub clock: Clock,                     // Current slot, epoch, and timestamp
-    pub epoch_rewards: EpochRewards,      // Epoch reward distribution info  
-    pub epoch_schedule: EpochSchedule,    // Epoch timing and slot configuration
-    pub last_restart_slot: LastRestartSlot, // Last validator restart information
-    pub rent: Rent,                       // Rent calculation parameters
-    pub slot_hashes: SlotHashes,          // Recent slot hash history
-    pub stake_history: StakeHistory,      // Historical stake activation data
-}
-```
-
-Vous pouvez personnaliser certains sysvars pour tester la logique dépendante du temps, les calculs de rente ou d'autres comportements dépendants du système, ou utiliser certaines fonctions d'aide :
 
 ```rust
 #[test]

--- a/src/app/content/courses/testing-with-mollusk/mollusk-101/en.mdx
+++ b/src/app/content/courses/testing-with-mollusk/mollusk-101/en.mdx
@@ -114,12 +114,12 @@ use solana_sdk::{
 let payer = Pubkey::new_unique();
 let payer_account = Account::new(100_000_000, 0, &system_program::id());
 
-// Uninitialized account with no lamports
-let uninitialized_account = Pubkey::new_unique();
-let uninitialized_account_account = Account::new(0, 0, &system_program::id());
+// Uninitialized account that requires nothing
+let some_temp_account = Pubkey::new_unique();
+let some_temp_account_account = Account::default();
 ```
 
-For `ProgramAccounts` that contain data, you have two construction approaches:
+For `ProgramAccounts` that contain data, construct `Account` with the correct fields set. Use Mollusk's rent sysvar to compute rent-exempt lamports:
 
 ```rust
 use solana_sdk::account::Account;
@@ -132,44 +132,24 @@ let lamports = mollusk
     .rent
     .minimum_balance(data.len());
 
-let program_account = Pubkey::new_unique();
-let program_account_account = Account {
+let program_account_pubkey = Pubkey::new_unique();
+let program_account = Account {
     lamports,
     data,
-    owner: ID, // The program's that owns the account
+    owner: ID,       // your program ID
     executable: false,
     rent_epoch: 0,
 };
-```
-
-Or using `AccountSharedData`:
-
-```rust
-use solana_sdk::account::AccountSharedData;
-
-let data = vec![
-    // Your serialized account data
-];
-let lamports = mollusk
-    .sysvars
-    .rent
-    .minimum_balance(data.len());
-
-let program_account = Pubkey::new_unique();
-let mut program_account_account = AccountSharedData::new(lamports, data.len(), &ID);
-program_account_account.set_data_from_slice(&data);
 ```
 
 Once you've created your accounts, compile them into the format Mollusk expects:
 
 ```rust
 let accounts = [
-    (user, user_account),
-    (program_account, program_account_account)
+    (payer, payer_account),
+    (program_account_pubkey, program_account),
 ];
 ```
-
-> When using AccountSharedData, remember to call `.into()` to convert it to the Account type that Mollusk requires for execution like this: `program_account_account.into()`.
 
 ### Instructions
 

--- a/src/app/content/courses/testing-with-mollusk/mollusk-101/fr.mdx
+++ b/src/app/content/courses/testing-with-mollusk/mollusk-101/fr.mdx
@@ -109,62 +109,42 @@ use solana_sdk::{
 let payer = Pubkey::new_unique();
 let payer_account = Account::new(100_000_000, 0, &system_program::id());
 
-// Uninitialized account with no lamports
-let uninitialized_account = Pubkey::new_unique();
-let uninitialized_account_account = Account::new(0, 0, &system_program::id());
+// Compte temporaire non initialisé qui ne nécessite rien
+let some_temp_account = Pubkey::new_unique();
+let some_temp_account_account = Account::default();
 ```
 
-Pour les `ProgramAccounts` qui contiennent des données, vous avez deux approches de construction :
+Pour les `ProgramAccounts` qui contiennent des données, construisez `Account` avec les champs corrects. Utilisez la sysvar de rente de Mollusk pour calculer les lamports exemptés de rente :
 
 ```rust
 use solana_sdk::account::Account;
 
 let data = vec![
-    // Your serialized account data
+    // Vos données de compte sérialisées
 ];
 let lamports = mollusk
     .sysvars
     .rent
     .minimum_balance(data.len());
 
-let program_account = Pubkey::new_unique();
-let program_account_account = Account {
+let program_account_pubkey = Pubkey::new_unique();
+let program_account = Account {
     lamports,
     data,
-    owner: ID, // The program's that owns the account
+    owner: ID,       // l'ID de votre programme
     executable: false,
     rent_epoch: 0,
 };
-```
-
-Ou en utilisant `AccountSharedData` :
-
-```rust
-use solana_sdk::account::AccountSharedData;
-
-let data = vec![
-    // Your serialized account data
-];
-let lamports = mollusk
-    .sysvars
-    .rent
-    .minimum_balance(data.len());
-
-let program_account = Pubkey::new_unique();
-let mut program_account_account = AccountSharedData::new(lamports, data.len(), &ID);
-program_account_account.set_data_from_slice(&data);
 ```
 
 Une fois vos comptes créés, compilez-les dans le format attendu par Mollusk :
 
 ```rust
 let accounts = [
-    (user, user_account),
-    (program_account, program_account_account)
+    (payer, payer_account),
+    (program_account_pubkey, program_account),
 ];
 ```
-
-> Lorsque vous utilisez `AccountSharedData` n'oubliez pas d'appeler `.into()` pour le convertir au type `Account` requis par Mollusk pour l'exécution, comme ceci : `program_account_account.into()`.
 
 ### Instructions
 


### PR DESCRIPTION
This pull request updates the advanced Mollusk testing course documentation in both English and French to simplify and modernize the examples for constructing test accounts, especially for SPL Token programs. The changes focus on using new official helper functions for creating pre-initialized token state, reducing boilerplate, and clarifying recommended patterns for account setup in Mollusk tests.

### SPL Token account initialization helpers

* Replaced manual account construction examples with usage of official helper functions from `mollusk-svm-programs-token` for creating pre-initialized SPL Token and Associated Token Accounts. This streamlines test setup and eliminates manual serialization, rent calculations, and address derivation. [[1]](diffhunk://#diff-22ba280a4a9be505e191ea13696b11eaf9028aea1ed93bf6e7853bfa82a76b37L108-R184) [[2]](diffhunk://#diff-b53e16f3fbe257516bd6fe464f72f68470774fdee30412b7616c516268a6eef4L108-R184)

### General account construction patterns

* Updated the basic account setup examples to recommend using `Account::default()` for uninitialized temporary accounts and clarified how to construct program-owned accounts using Mollusk’s rent sysvar for proper lamport calculation. [[1]](diffhunk://#diff-7bb1d167efa2b841487a91255c962704d9b085a7e301335e67d5ad5f763c08c8L117-R122) [[2]](diffhunk://#diff-6d8d5f745d5a70e64f44214f250f985537325e71a33a626902f07df8f7beeb3bL112-L168)
* Removed secondary approach using `AccountSharedData` for test account construction, focusing documentation on the recommended single approach. [[1]](diffhunk://#diff-7bb1d167efa2b841487a91255c962704d9b085a7e301335e67d5ad5f763c08c8L135-L173) [[2]](diffhunk://#diff-6d8d5f745d5a70e64f44214f250f985537325e71a33a626902f07df8f7beeb3bL112-L168)

### Documentation clarity and cleanup

* Improved variable naming for clarity (e.g., `program_account_pubkey`) and updated code comments to better explain account setup steps. [[1]](diffhunk://#diff-7bb1d167efa2b841487a91255c962704d9b085a7e301335e67d5ad5f763c08c8L135-L173) [[2]](diffhunk://#diff-6d8d5f745d5a70e64f44214f250f985537325e71a33a626902f07df8f7beeb3bL112-L168)
* Removed redundant code and outdated sysvars struct documentation to keep the content focused and current.