### PR TITLE
Update borrow.mdx

### DIFF
--- a/src/app/content/challenges/anchor-flash-loan/en/pages/borrow.mdx
+++ b/src/app/content/challenges/anchor-flash-loan/en/pages/borrow.mdx
@@ -71,6 +71,10 @@ Finally, we perform the most critical check: ensuring that the last instruction 
     Make sure that the last instruction of this transaction is a repay instruction
 */
 
+// Check if this is the first instruction in the transaction.
+let current_index = load_current_index_checked(&ctx.accounts.sysvar_instructions)?;
+require_eq!(current_index, 0, ProtocolError::InvalidIx); 
+
 // Check how many instruction we have in this transaction
 let instruction_sysvar = ixs.try_borrow_data()?;
 let len = u16::from_le_bytes(instruction_sysvar[0..2].try_into().unwrap());


### PR DESCRIPTION
Prevent borrows, that pass without repays.
The borrow instruction does not check if it is the only borrow instruction by checking if it is at index 0, making it possible to make many borrows with only one repay.