### PR TITLE
fix: updated raw instructions 

### DIFF
--- a/src/app/content/courses/spl-token-with-web3js/introduction/en.mdx
+++ b/src/app/content/courses/spl-token-with-web3js/introduction/en.mdx
@@ -126,7 +126,11 @@ import {
     TOKEN_PROGRAM_ID,
 } from "@solana/spl-token";
 
+(async() => {
+const connection = new Connection(clusterApiUrl("devnet"), "confirmed");
+
 const token = Keypair.generate();
+const feePayer = Keypair.generate();
 
 const tokenRent = await getMinimumBalanceForRentExemptAccount(connection);
 
@@ -150,9 +154,10 @@ const transaction = new Transaction().add(
     initializeTokenInstruction,
 );
 
-const signature = await sendAndConfirmTransaction(connection, transaction, [keypair, token]);
+const signature = await sendAndConfirmTransaction(connection, transaction, [feePayer, token]);
 
 console.log(`Token created! Check out your TX here: https://explorer.solana.com/tx/${signature}?cluster=devnet`);
+})();
 ```
 
 But same as the `Mint` account, the `@solana/spl-token` package has some abstraction to create the `Token` account. We can use the `createAccount()` function like so:
@@ -174,15 +179,24 @@ So here's how we create an `Associated Token` account without any abstractions:
 
 ```ts
 import {
+    clusterApiUrl,
+    Connection,
+    Keypair,
     sendAndConfirmTransaction,
     Transaction,
 } from "@solana/web3.js";
 
 import {
-    TOKEN_PROGRAM_ID
+    TOKEN_PROGRAM_ID,
     createAssociatedTokenAccountIdempotentInstruction,
     getAssociatedTokenAddress,
 } from "@solana/spl-token";
+
+(async() => {
+
+const connection = new Connection(clusterApiUrl("devnet"), "confirmed");
+
+const keypair = Keypair.generate();
 
 const associatedTokenAccount = await getAssociatedTokenAddress(
     mint.publicKey, // mint pubkey
@@ -207,6 +221,7 @@ const transaction = new Transaction().add(
 const signature = await sendAndConfirmTransaction(connection, transaction, [keypair]);
 
 console.log(`Associated Token created! Check out your TX here: https://explorer.solana.com/tx/${signature}?cluster=devnet`);
+})();
 ```
 
 And here's how it looks with abstractions: 

--- a/src/app/content/courses/spl-token-with-web3js/introduction/en.mdx
+++ b/src/app/content/courses/spl-token-with-web3js/introduction/en.mdx
@@ -26,6 +26,8 @@ Without any abstraction, creating a `Mint` account would look like this:
 
 ```ts
 import {
+    clusterApiUrl,
+    Connection,
     Keypair,
     sendAndConfirmTransaction,
     SystemProgram,
@@ -39,9 +41,32 @@ import {
     TOKEN_PROGRAM_ID,
 } from "@solana/spl-token";
 
+(async() => {
+
+const connection = new Connection(clusterApiUrl("devnet"), "confirmed");
+
 const mint = Keypair.generate();
+const feePayer = Keypair.generate();
 
 const mintRent = await getMinimumBalanceForRentExemptMint(connection);
+
+const existingBalance = await connection.getBalance(feePayer.publicKey);
+console.log("Existing balance:", existingBalance);
+
+if (existingBalance < mintRent + 5000) { // Need extra for transaction fees
+    console.log("Requesting airdrop...");
+    const airdropSignature = await connection.requestAirdrop(feePayer.publicKey, 1_000_000_000);
+
+    const confirmationResult = await connection.confirmTransaction(airdropSignature, "confirmed");
+
+    if (confirmationResult.value.err) {
+        throw new Error(`Airdrop failed: ${confirmationResult.value.err}`);
+    }
+
+    console.log("Airdrop confirmed!");
+
+    await new Promise(resolve => setTimeout(resolve, 1000));
+}
 
 const createAccountInstruction = SystemProgram.createAccount({
     fromPubkey: feePayer.publicKey,
@@ -64,9 +89,10 @@ const transaction = new Transaction().add(
     initializeMintInstruction,
 );
 
-const signature = await sendAndConfirmTransaction(connection, transaction, [keypair, mint]);
+const signature = await sendAndConfirmTransaction(connection, transaction, [feePayer, mint]);
 
 console.log(`Mint created! Check out your TX here: https://explorer.solana.com/tx/${signature}?cluster=devnet`);
+})();
 ```
 
 Thankfully, the `@solana/spl-token` package has some abstraction. So we can create a `Mint` account with a single `createMint()` function like so: 


### PR DESCRIPTION
The raw instructions code was buggy and there were some errors, which have been fixed for the following sections in the introduction page of the SPL Token with web3.js course - 
1. Mint
2. Token Account
3. Associated Token Accounts