### PR TITLE
fix: Replace initializeMintCloseAuthority with initializeDefaultAccountState

### DIFF
--- a/src/app/content/courses/token-2022-with-web3js/default-account-state-extension/en.mdx
+++ b/src/app/content/courses/token-2022-with-web3js/default-account-state-extension/en.mdx
@@ -61,7 +61,7 @@ const initializeMintInstruction = createInitializeMintInstruction(
 // Combine all instructions in the correct order
 const transaction = new Transaction().add(
     createAccountInstruction,
-    initializeMintCloseAuthority,
+    initializeDefaultAccountState,
     initializeMintInstruction,
 );
 

--- a/src/app/content/courses/token-2022-with-web3js/default-account-state-extension/fr.mdx
+++ b/src/app/content/courses/token-2022-with-web3js/default-account-state-extension/fr.mdx
@@ -61,7 +61,7 @@ const initializeMintInstruction = createInitializeMintInstruction(
 // Combine all instructions in the correct order
 const transaction = new Transaction().add(
     createAccountInstruction,
-    initializeMintCloseAuthority,
+    initializeDefaultAccountState,
     initializeMintInstruction,
 );
 

--- a/src/app/content/courses/token-2022-with-web3js/default-account-state-extension/vi.mdx
+++ b/src/app/content/courses/token-2022-with-web3js/default-account-state-extension/vi.mdx
@@ -61,7 +61,7 @@ const initializeMintInstruction = createInitializeMintInstruction(
 // Combine all instructions in the correct order
 const transaction = new Transaction().add(
     createAccountInstruction,
-    initializeMintCloseAuthority,
+    initializeDefaultAccountState,
     initializeMintInstruction,
 );
 

--- a/src/app/content/courses/token-2022-with-web3js/default-account-state-extension/zh-CN.mdx
+++ b/src/app/content/courses/token-2022-with-web3js/default-account-state-extension/zh-CN.mdx
@@ -61,7 +61,7 @@ const initializeMintInstruction = createInitializeMintInstruction(
 // Combine all instructions in the correct order
 const transaction = new Transaction().add(
     createAccountInstruction,
-    initializeMintCloseAuthority,
+    initializeDefaultAccountState,
     initializeMintInstruction,
 );
 


### PR DESCRIPTION
Added incorrect instructions to the transaction. 
The correct instruction to add should have been initializeDefaultAccountState, but initializeMintCloseAuthority was incorrectly added instead. initializeMintCloseAuthority does not exist.