### PR TITLE
update path of file to differentiate 2 cargo.toml file

### DIFF
--- a/src/app/content/challenges/anchor-escrow/en/challenge.mdx
+++ b/src/app/content/challenges/anchor-escrow/en/challenge.mdx
@@ -38,7 +38,7 @@ cargo add anchor-spl
 ```
 </Codeblock>
 
-Since we're using `anchor-spl`, we also need to update the `Cargo.toml` file to include `anchor-spl/idl-build` in the `idl-build` feature. 
+Since we're using `anchor-spl`, we also need to update the `programs/Cargo.toml` file to include `anchor-spl/idl-build` in the `idl-build` feature. 
 
 Open `Cargo.toml` and you'll see an existing `idl-build` line that looks like this:
 


### PR DESCRIPTION
I know this is pretty simple stuff but it can help for people who would be confused with the two cargo toml files created by anchor init