### PR TITLE
Fix: General fixes

### DIFF
--- a/messages/en/courses.json
+++ b/messages/en/courses.json
@@ -31,6 +31,7 @@
         "pinocchio-instructions": "Pinocchio Instructions",
         "pinocchio-errors": "Pinocchio Errors",
         "reading-and-writing-data": "Reading and Writing Data",
+        "testing-your-program": "Testing your Program",
         "performance": "Performance",
         "conclusion": "Conclusion"
       }

--- a/src/app/content/courses/courses.ts
+++ b/src/app/content/courses/courses.ts
@@ -44,6 +44,7 @@ const allCourses: CourseMetadata[] = withCourseNumber([
       { slug: "pinocchio-instructions" },
       { slug: "pinocchio-errors" },
       { slug: "reading-and-writing-data" },
+      { slug: "testing-your-program" },
       { slug: "performance" },
       { slug: "conclusion" },
     ],

--- a/src/app/content/courses/introduction-to-pinocchio/testing-your-program/en.mdx
+++ b/src/app/content/courses/introduction-to-pinocchio/testing-your-program/en.mdx
@@ -1,0 +1,32 @@
+import { ArticleSection } from "../../../../components/ArticleSection/ArticleSection";
+
+# Testing your Program  
+
+Thorough testing is essential before mainnet deployment to identify potential bugs and vulnerabilities. 
+
+Well-tested programs prevent financial losses, build user trust, and ensure applications behave correctly under various conditions.
+
+<ArticleSection name="Mollusk Tests" id="mollusk-tests" level="h2" />
+
+When setting up complex program states or requiring intricate onchain interactions proves difficult, Mollusk provides more granular control over the testing environment.
+
+Mollusk is a Rust testing framework designed specifically for Solana programs that enables you to:
+- Test program logic in isolation without network overhead
+- Set up complex account states and program conditions easily
+- Run tests faster than full integration tests
+- Mock specific blockchain conditions and edge cases
+
+We covered Mollusk testing thoroughly [here](/en/courses/testing-with-mollusk).
+
+To test your pinocchio program, just import your `test.rs` file with the `test` config flag in your `lib.rs`:
+
+```rust
+#[cfg(test)]
+pub mod tests;
+```
+
+Run your tests using:
+
+```
+cargo test-sbf
+```


### PR DESCRIPTION
- Added a `testing-your-program` lesson to `introduction-to-pinocchio`.
- Added a link in the `conclusion` of `testing-with-mollusk` a link back to the testing part of `anchor-for-dummies` and `introduction-to-pinocchio`.
- Fixed #189 in the `advanced-functionalities` lesson of the `testing-with-mollusk` course.
- Fixed #81 in the `pinocchio-flash-loan` challenge

This closes #208 