### PR TITLE
fix: several things in introduction-to-assembly course

### DIFF
--- a/src/app/content/courses/introduction-to-assembly/assembly-101/en.mdx
+++ b/src/app/content/courses/introduction-to-assembly/assembly-101/en.mdx
@@ -42,10 +42,10 @@ Additionally, sBPF includes syscalls for account access, cross-program calls, an
 ### Why Understanding sBPF Assembly Matters
 
 While the Rust compiler efficiently translates high-level code into sBPF instructions, understanding assembly provides several advantages:
-**Understanding Compute Costs**: Every sBPF instruction consumes compute units (CUs). A single line of Rust can compile to hundreds of instructions—assembly reveals why certain operations are expensive.
-**Smaller Program Sizes**: Programs written directly in sBPF assembly are dramatically smaller than compiled Rust equivalents, reducing deployment costs and improving load times.
-**Optimization Opportunities**: The Rust compiler generates safe, correct code but not always the most efficient. Assembly exposes redundant safety checks and suboptimal instruction sequences.
-**Debugging and Analysis**: When programs behave unexpectedly, assembly provides ground truth. You can trace exactly which instructions executed and identify failure points.
+- **Understanding Compute Costs**: Every sBPF instruction consumes compute units (CUs). A single line of Rust can compile to hundreds of instructions—assembly reveals why certain operations are expensive.
+- **Smaller Program Sizes**: Programs written directly in sBPF assembly are dramatically smaller than compiled Rust equivalents, reducing deployment costs and improving load times.
+- **Optimization Opportunities**: The Rust compiler generates safe, correct code but not always the most efficient. Assembly exposes redundant safety checks and suboptimal instruction sequences.
+- **Debugging and Analysis**: When programs behave unexpectedly, assembly provides ground truth. You can trace exactly which instructions executed and identify failure points.
 
 ### Architecture
 

--- a/src/app/content/courses/introduction-to-assembly/instructions/en.mdx
+++ b/src/app/content/courses/introduction-to-assembly/instructions/en.mdx
@@ -49,36 +49,36 @@ Different instruction types use these fields in specific ways:
 - **Data Movement**: Move values between registers and memory:
 
 ```sbpf
-mov64 r1, 42           # Put immediate value 42 into r1
-                       # opcode=move_imm, dst=1, src=unused, imm=42
+mov64 r1, 42           // Put immediate value 42 into r1
+                       // opcode=move_imm, dst=1, src=unused, imm=42
 
-ldxdw r0, [r10 - 8]    # Load 8 bytes from stack into r0  
-                       # opcode=load64, dst=0, src=10, offset=-8, imm=unused
+ldxdw r0, [r10 - 8]    // Load 8 bytes from stack into r0  
+                       // opcode=load64, dst=0, src=10, offset=-8, imm=unused
 
-stxdw [r1 + 16], r0    # Store r0 to memory at [r1 + 16]
-                       # opcode=store64, dst=1, src=0, offset=16, imm=unused
+stxdw [r1 + 16], r0    // Store r0 to memory at [r1 + 16]
+                       // opcode=store64, dst=1, src=0, offset=16, imm=unused
 ```
 - **Arithmetic**: Perform mathematical operations:
 
 ```sbpf
-add64 r1, r2           # r1 = r1 + r2
-                       # opcode=add_reg, dst=1, src=2, offset=unused, imm=unused
+add64 r1, r2           // r1 = r1 + r2
+                       // opcode=add_reg, dst=1, src=2, offset=unused, imm=unused
 
-add64 r1, 100          # r1 = r1 + 100  
-                       # opcode=add_imm, dst=1, src=unused, offset=unused, imm=100
+add64 r1, 100          // r1 = r1 + 100  
+                       // opcode=add_imm, dst=1, src=unused, offset=unused, imm=100
 ```
 
 - **Control Flow**: Change execution sequence:
 
 ```sbpf
-ja +5                  # Jump forward 5 instructions unconditionally
-                       # opcode=jump, dst=unused, src=unused, offset=5, imm=unused
+ja +5                  // Jump forward 5 instructions unconditionally
+                       // opcode=jump, dst=unused, src=unused, offset=5, imm=unused
 
-jeq r1, r2, +3         # If r1 == r2, jump forward 3 instructions
-                       # opcode=jump_eq_reg, dst=1, src=2, offset=3, imm=unused
+jeq r1, r2, +3         // If r1 == r2, jump forward 3 instructions
+                       // opcode=jump_eq_reg, dst=1, src=2, offset=3, imm=unused
 
-jeq r1, 42, +3         # If r1 == 42, jump forward 3 instructions  
-                       # opcode=jump_eq_imm, dst=1, src=unused, offset=3, imm=42
+jeq r1, 42, +3         // If r1 == 42, jump forward 3 instructions  
+                       // opcode=jump_eq_imm, dst=1, src=unused, offset=3, imm=42
 ```
 
 ### Opcode Encoding

--- a/src/app/content/courses/introduction-to-assembly/program-example/en.mdx
+++ b/src/app/content/courses/introduction-to-assembly/program-example/en.mdx
@@ -38,7 +38,7 @@ fn process_instruction(
 
 If we build this code with `cargo build-sbf --dump`, we will get an ELF dump that gives us information about our binary in the `/target/deploy/` directory.
 
-We will then want to look for the `.text` section; the part of our binary where executable code is stored.
+We will then want to look for the `.text` section — the part of our binary where executable code is stored.
 
 ```pinocchio_noop-dump.txt
 Disassembly of section .text
@@ -69,14 +69,15 @@ And this is the second instruction: `128 95 00 00 00 00 00 00 00`
 If we were to disassemble the binary to turn it back into compilable sBPF Assembly, the code would look like this:
 
 ```sbpf
-.globl entrypoint:
-    mov64 r0, 0x00   ; r0 <- success
-    exit             ; finish, return r0
+.globl entrypoint
+entrypoint:
+    mov64 r0, 0x00   # r0 <- success
+    exit             # finish, return r0
 ```
 
 Let's break down the code:
 - `.globl entrypoint`: This is an assembler directive that tells the linker to make the entrypoint symbol globally visible. The Solana runtime looks for this symbol to know where to start executing your program.
-- `entrypoint`:: This is a label that marks the memory address where program execution begins. When the runtime loads your program, it jumps to this address.
+- `entrypoint`: This is a label that marks the memory address where program execution begins. When the runtime loads your program, it jumps to this address.
 - `mov64 r0, 0x00`: Move the immediate value 0 into register r0. Since r0 is the return register, this sets up a success return code.
 - `exit`: Terminate program execution and return the value in r0 to the runtime.
 
@@ -92,7 +93,8 @@ This is an extremely small program, with just 2 instructions consuming only 2 co
 However, we can optimize this further. Since the Solana runtime initializes `r0` to 0 by default, we can eliminate the redundant `mov64` instruction:
 
 ```sbpf
-.globl entrypoint:
+.globl entrypoint
+entrypoint:
     exit
 ```
 
@@ -102,4 +104,4 @@ This optimized version:
 
 > This is why understanding assembly helps with optimization!
 
-This optimization is possible because we know the initial register states; something the Rust compiler doesn't always take advantage of. Understanding sBPF assembly lets you identify and eliminate such inefficiencies in performance-critical code.
+This optimization is possible because we know the initial register states — something the Rust compiler doesn't always take advantage of. Understanding sBPF assembly lets you identify and eliminate such inefficiencies in performance-critical code.

--- a/src/app/content/courses/introduction-to-assembly/program-example/en.mdx
+++ b/src/app/content/courses/introduction-to-assembly/program-example/en.mdx
@@ -71,8 +71,8 @@ If we were to disassemble the binary to turn it back into compilable sBPF Assemb
 ```sbpf
 .globl entrypoint
 entrypoint:
-    mov64 r0, 0x00   # r0 <- success
-    exit             # finish, return r0
+    mov64 r0, 0x00   // r0 <- success
+    exit             // finish, return r0
 ```
 
 Let's break down the code:

--- a/src/app/content/courses/introduction-to-assembly/registers-and-memory/en.mdx
+++ b/src/app/content/courses/introduction-to-assembly/registers-and-memory/en.mdx
@@ -52,14 +52,14 @@ Here's how registers and memory work together in practice:
 ```sbpf
 .globl entrypoint
 entrypoint:
-    # On entry: r1 points to input data at 0x400000000
+    // On entry: r1 points to input data at 0x400000000
     
-    ldxdw r0, [r1 + 0]      # Load first 8 bytes from input into r0
-    mov64 r2, 42            # Put 42 in register r2
-    add64 r0, r2            # Add them: r0 = r0 + r2
+    ldxdw r0, [r1 + 0]      // Load first 8 bytes from input into r0
+    mov64 r2, 42            // Put 42 in register r2
+    add64 r0, r2            // Add them: r0 = r0 + r2
     
-    stxdw [r10 - 8], r0     # Store result on stack
-    mov64 r0, 0             # Return success
+    stxdw [r10 - 8], r0     // Store result on stack
+    mov64 r0, 0             // Return success
     exit
 ```
 
@@ -76,11 +76,11 @@ The workflow follows a consistent pattern: load data from memory into registers,
 The stack operates with `r10` as the frame pointer, pointing to the base of your current stack frame (the highest address). Local variables use negative offsets:
 
 ```sbpf
-# Store a value on the stack
+// Store a value on the stack
 mov64 r0, 42
 stxdw [r10 - 8], r0         // Store at first stack slot
 
-# Load it back
+// Load it back
 ldxdw r1, [r10 - 8]         // Load from first stack slot
 ```
 
@@ -93,15 +93,15 @@ Your program begins execution at the symbol marked with `.globl` (typically entr
 ```sbpf
 .globl entrypoint
 entrypoint:
-    # On entry:
-    # r1 = 0x400000000 (input buffer pointer)
-    # r10 = 0x200001000 (0x200000000 stack start + 0x1000 4KiB frame size)
-    # r0, r2-r9 = 0 (all other registers zeroed)
+    // On entry:
+    // r1 = 0x400000000 (input buffer pointer)
+    // r10 = 0x200001000 (0x200000000 stack start + 0x1000 4KiB frame size)
+    // r0, r2-r9 = 0 (all other registers zeroed)
 
-    # Your program logic here
+    // Your program logic here
 
-    mov64 r0, 0     # Success code (0 = SUCCESS)
-    exit            # Return to runtime
+    mov64 r0, 0     // Success code (0 = SUCCESS)
+    exit            // Return to runtime
 ```
 
 Exit behavior depends on call depth:

--- a/src/app/content/courses/introduction-to-assembly/registers-and-memory/en.mdx
+++ b/src/app/content/courses/introduction-to-assembly/registers-and-memory/en.mdx
@@ -78,7 +78,7 @@ The stack operates with `r10` as the frame pointer, pointing to the base of your
 ```sbpf
 # Store a value on the stack
 mov64 r0, 42
-stxdw [r10 - 8], r0         # Store at first stack slot
+stxdw [r10 - 8], r0         // Store at first stack slot
 
 # Load it back
 ldxdw r1, [r10 - 8]         # Load from first stack slot

--- a/src/app/content/courses/introduction-to-assembly/registers-and-memory/en.mdx
+++ b/src/app/content/courses/introduction-to-assembly/registers-and-memory/en.mdx
@@ -20,7 +20,7 @@ sBPF assigns specific roles to each register:
 | `r6-r9`  | General purpose      | Yes            | Must preserve across calls                  |
 | `r10`    | Frame pointer        | Yes, read-only | Stack base, cannot modify directly          |
 
-Registers `r6` through `r9` are "callee-saved", meaning their values persist across function calls. Use these for important data that must survive function invocations. 
+Registers `r6` through `r9` are _callee-saved_, meaning their values persist across function calls. Use these for important data that must survive function invocations. 
 
 The remaining registers (`r0`-`r5`) get overwritten during syscalls and function calls.
 
@@ -95,7 +95,7 @@ Your program begins execution at the symbol marked with `.globl` (typically entr
 entrypoint:
     # On entry:
     # r1 = 0x400000000 (input buffer pointer)
-    # r10 = 0x200001000 (stack base)
+    # r10 = 0x200001000 (0x200000000 stack start + 0x1000 4KiB frame size)
     # r0, r2-r9 = 0 (all other registers zeroed)
 
     # Your program logic here

--- a/src/app/content/courses/introduction-to-assembly/registers-and-memory/en.mdx
+++ b/src/app/content/courses/introduction-to-assembly/registers-and-memory/en.mdx
@@ -81,7 +81,7 @@ mov64 r0, 42
 stxdw [r10 - 8], r0         // Store at first stack slot
 
 # Load it back
-ldxdw r1, [r10 - 8]         # Load from first stack slot
+ldxdw r1, [r10 - 8]         // Load from first stack slot
 ```
 
 Stack slots are typically 8 bytes wide, so consecutive variables use offsets like `[r10 - 8]`, `[r10 - 16]`, `[r10 - 24]`, and so on.

--- a/src/app/content/courses/introduction-to-assembly/registers-and-memory/en.mdx
+++ b/src/app/content/courses/introduction-to-assembly/registers-and-memory/en.mdx
@@ -20,7 +20,7 @@ sBPF assigns specific roles to each register:
 | `r6-r9`  | General purpose      | Yes            | Must preserve across calls                  |
 | `r10`    | Frame pointer        | Yes, read-only | Stack base, cannot modify directly          |
 
-Registers `r6` through `r9` are "callee-saved," meaning their values persist across function calls. Use these for important data that must survive function invocations. 
+Registers `r6` through `r9` are "callee-saved", meaning their values persist across function calls. Use these for important data that must survive function invocations. 
 
 The remaining registers (`r0`-`r5`) get overwritten during syscalls and function calls.
 
@@ -30,15 +30,15 @@ Register `r10` is "special" because it serves as your frame pointer, pointing to
 
 While registers hold actively used values, memory stores everything else. sBPF organizes memory into fixed regions with identical layouts across all programs:
 
-| Region | Start Address | Purpose                 | Size/Notes             |
-|--------|---------------|-------------------------|------------------------|
-| Text   | 0x100000000   | Code and read-only data | Program binary         |
-| Stack  | 0x200000000   | Local variables         | 32 KiB, grows downward |
-| Heap   | 0x300000000   | Dynamic allocation      | Via `sol_alloc_free`   |
-| Input  | 0x400000000   | Program parameters      | Serialized arguments   |
+| Region | Start Address | Purpose                 | Size/Notes                                             |
+|--------|---------------|-------------------------|--------------------------------------------------------|
+| Text   | 0x100000000   | Code and read-only data | Program binary                                         |
+| Stack  | 0x200000000   | Local variables         | 4 KiB per stack frame, with a maximum call depth of 64 |
+| Heap   | 0x300000000   | Dynamic allocation      | 32 KiB                                                 |
+| Input  | 0x400000000   | Program parameters      | Serialized accounts and instruction data               |
 
 - The **text region** contains your executable code and read-only data like string constants. Data defined with `.quad` directives typically resides here.
-- The **stack region** houses local variables. With `r10` pointing to the stack base, you access locals using negative offsets: `[r10 - 16]`, `[r10 - 24]`, etc. The stack is limited to 32 KiB total.
+- The **stack region** houses local variables. With `r10` pointing to the stack base, you access locals using negative offsets: `[r10 - 16]`, `[r10 - 24]`, etc.
 - The **input region** contains your program's parameters. On entry, `r1` points to this region (`0x400000000`), allowing you to read serialized account data and instruction parameters passed to your program.
 
 This fixed layout provides three key benefits: security through memory isolation between programs, determinism with identical addresses across all validators, and performance through compiler optimizations for known locations.
@@ -78,10 +78,10 @@ The stack operates with `r10` as the frame pointer, pointing to the base of your
 ```sbpf
 # Store a value on the stack
 mov64 r0, 42
-stxdw [r10 - 8], r0         ; Store at first stack slot
+stxdw [r10 - 8], r0         # Store at first stack slot
 
 # Load it back
-ldxdw r1, [r10 - 8]         ; Load from first stack slot
+ldxdw r1, [r10 - 8]         # Load from first stack slot
 ```
 
 Stack slots are typically 8 bytes wide, so consecutive variables use offsets like `[r10 - 8]`, `[r10 - 16]`, `[r10 - 24]`, and so on.
@@ -95,7 +95,8 @@ Your program begins execution at the symbol marked with `.globl` (typically entr
 entrypoint:
     # On entry:
     # r1 = 0x400000000 (input buffer pointer)
-    # r0, r2-r10 = 0 (all other registers zeroed)
+    # r10 = 0x200001000 (stack base)
+    # r0, r2-r9 = 0 (all other registers zeroed)
 
     # Your program logic here
 


### PR DESCRIPTION
1. Changes in memory layout table:
- Updated the description of the stack region: it is not 32 KiB, but 4 × 64 KiB. Also removed “grows downward” since it could be misinterpreted as the stack growing below the 0x200000000 address.
- Removed the mention of `sol_alloc_free`, as it was removed some time ago.
2. Changed `;` to `#` in couple of places
3. Some typos and formatting