### PR TITLE
chore: Hook ``` to generate Codeblock component in MDX

### DIFF
--- a/mdx-components.tsx
+++ b/mdx-components.tsx
@@ -12,11 +12,11 @@ export function useMDXComponents(components: MDXComponents): MDXComponents {
   return {
     ...components,
     ArticleSection,
-    Codeblock,
     IDE,
     RequirementList,
     Requirement,
     AnchorDiscriminatorCalculator,
+    pre: Codeblock,
     blockquote: ({ children }) => (
       <blockquote className="bg-background-primary rounded-xl flex items-start gap-x-2 py-4 px-6">
         <Icon

--- a/src/app/components/Codeblock/Codeblock.tsx
+++ b/src/app/components/Codeblock/Codeblock.tsx
@@ -6,15 +6,16 @@ import { motion } from "motion/react";
 import classNames from "classnames";
 import { anticipate } from "motion";
 
-export function Codeblock({
-  children,
-  lang,
-}: {
+interface CodeblockProps {
   children: React.ReactNode;
-  lang: string;
-}) {
+  'data-language'?: string;
+}
+
+export function Codeblock(props: CodeblockProps) {
   const preRef = useRef<HTMLDivElement>(null);
   const [isCopied, setIsCopied] = useState(false);
+  const children = props.children;
+  const lang = props['data-language'];
 
   const handleClickCopy = async () => {
     const code = preRef.current?.textContent;
@@ -32,7 +33,7 @@ export function Codeblock({
   return (
     <div className="flex flex-col w-full border border-border rounded-xl overflow-hidden !my-8">
       <div className="text-sm font-medium text-brand-secondary flex items-center justify-between px-6 py-3 border-b-border bg-background-card-foreground rounded-t-xl">
-        {lang}
+        {lang || "\u00A0"}
         {children && (
           <motion.div
             initial={{ opacity: 0 }}
@@ -59,7 +60,9 @@ export function Codeblock({
         )}
       </div>
       <div className="bg-background-card" ref={preRef}>
-        {children}
+        <pre className="m-0!">
+          {children}
+        </pre>
       </div>
     </div>
   );

--- a/src/app/content/challenges/anchor-escrow/en/challenge.mdx
+++ b/src/app/content/challenges/anchor-escrow/en/challenge.mdx
@@ -1,5 +1,4 @@
 import { ArticleSection } from "../../../../components/ArticleSection/ArticleSection";
-import { Codeblock } from "../../../../components/Codeblock/Codeblock";
 
 ![Anchor Escrow Challenge](/graphics/challenge-banners/anchor-escrow.png)
 
@@ -22,21 +21,17 @@ In this challenge, we're going to implement this concept through three simple bu
 
 Let's start by creating a fresh Anchor workspace:
 
-<Codeblock lang="terminal">
 ```bash
 anchor init blueshift_anchor_escrow
 cd blueshift_anchor_escrow
 ```
-</Codeblock>
 
 We then continue by enabling `init-if-needed` on the `anchor-lang` crate and by adding the `anchor-spl` crate as well:
 
-<Codeblock lang="terminal">
 ```bash
 cargo add anchor-lang --features init-if-needed
 cargo add anchor-spl
 ```
-</Codeblock>
 
 Since we're using `anchor-spl`, we also need to update the `programs/blueshift_anchor_escrow/Cargo.toml` file to include `anchor-spl/idl-build` in the `idl-build` feature. 
 
@@ -74,7 +69,6 @@ src
 
 Which the `lib.rs` will look roughly like this:
 
-<Codeblock lang="rust">
 ```rust
 use anchor_lang::prelude::*;
 
@@ -105,7 +99,6 @@ pub mod blueshift_anchor_escrow {
     }
 }
 ```
-</Codeblock>
 
 As you see, we implemented custom discriminator for the instructions. So make sure to use an anchor version 0.31.0 or newer.
 
@@ -113,7 +106,6 @@ As you see, we implemented custom discriminator for the instructions. So make su
 
 We're going to move into the `state.rs` where all the data for our `Escrow` lives. To do so we're going to give it a custom discriminator and wrap the struct into the `#[account]` macro like this:
 
-<Codeblock lang="rust">
 ```rust
 use anchor_lang::prelude::*;
 
@@ -128,7 +120,6 @@ pub struct Escrow {
     pub bump: u8,
 }
   ```
-</Codeblock>
 
 What each field does:
 - **seed**: Random number used during seed derivation so one maker can open multiple escrows with the same token pair; stored on-chain so we can always re-derive the PDA.
@@ -145,7 +136,6 @@ We finish by adding the `#[derive(InitSpace)]` macro so we don't have to manuall
 
 We can now move to the `errors.rs` file where we're going to add some errors that we're going to use later like this: 
 
-<Codeblock lang="rust">
 ```rust
 use anchor_lang::prelude::*;
 
@@ -161,6 +151,5 @@ pub enum EscrowError {
     InvalidMintB,
 }
 ```
-</Codeblock>
 
 Each enum maps to a clear, human-readable message that Anchor will surface whenever a constraint or `require!()` fails.

--- a/src/app/content/challenges/anchor-escrow/en/pages/make.mdx
+++ b/src/app/content/challenges/anchor-escrow/en/pages/make.mdx
@@ -1,5 +1,4 @@
 import { ArticleSection } from "../../../../../components/ArticleSection/ArticleSection";
-import { Codeblock } from "../../../../../components/Codeblock/Codeblock";
 
 <ArticleSection name="Make" id="make" level="h2" />
 
@@ -23,7 +22,6 @@ The accounts needed in this context are:
 
 And with all the constraint it will look something like this:
 
-<Codeblock lang="rust">
 ```rust
 #[derive(Accounts)]
 #[instruction(seed: u64)]
@@ -70,7 +68,6 @@ pub struct Make<'info> {
     pub system_program: Program<'info, System>,
 }
 ```
-</Codeblock>
 
 **Note**: This instruction passes a single token_program. Because take transfers for both mints, we must ensure both mints are owned by that same program (SPL Token or Token-2022), or the CPI will fail.
 
@@ -80,7 +77,6 @@ After initializing the Accounts, we can finally handle the logic by creating sma
 
 We start by populating the `Escrow` using the `set_inner()` helper, and we then move onto depositing the tokens through the `transfer` CPI like this:
 
-<Codeblock lang="rust">
 ```rust
 impl<'info> Make<'info> {
     /// # Create the Escrow
@@ -117,7 +113,6 @@ impl<'info> Make<'info> {
     }
 }
 ```
-</Codeblock>
 
 We can see that Anchor helps us in multiple ways:
 - `set_inner()`: guarantees every field is populated.
@@ -125,7 +120,6 @@ We can see that Anchor helps us in multiple ways:
 
 And now we can move onto creating an `handler` function where we perform some checks before using the helpers, like this:
 
-<Codeblock lang="rust">
 ```rust
 pub fn handler(ctx: Context<Make>, seed: u64, receive: u64, amount: u64) -> Result<()> {
     // Validate the amount
@@ -141,7 +135,6 @@ pub fn handler(ctx: Context<Make>, seed: u64, receive: u64, amount: u64) -> Resu
     Ok(())
 }
   ```
-</Codeblock>
 
 Here we add two validation checks; one on the `amount` and one on the `receive` arguments to ensure we're not passing a zero value for either.
 

--- a/src/app/content/challenges/anchor-escrow/en/pages/refund.mdx
+++ b/src/app/content/challenges/anchor-escrow/en/pages/refund.mdx
@@ -1,5 +1,4 @@
 import { ArticleSection } from "../../../../../components/ArticleSection/ArticleSection";
-import { Codeblock } from "../../../../../components/Codeblock/Codeblock";
 
 <ArticleSection name="Refund" id="refund" level="h2" />
 
@@ -33,7 +32,6 @@ Just know that once this executes, the offer is void, the vault is gone, and the
 
 Now that we created all the function in the different instruction, we can finally populate the `lib.rs` with all the function we created; like this:
 
-<Codeblock lang="rust">
 ```rust
 #[program]
 pub mod blueshift_anchor_escrow {
@@ -52,7 +50,6 @@ pub mod blueshift_anchor_escrow {
     }
 }
 ```
-</Codeblock>
 
 <ArticleSection name="Conclusion" id="conclusion" level="h2" />
 

--- a/src/app/content/challenges/anchor-escrow/en/pages/take.mdx
+++ b/src/app/content/challenges/anchor-escrow/en/pages/take.mdx
@@ -1,5 +1,4 @@
 import { ArticleSection } from "../../../../../components/ArticleSection/ArticleSection";
-import { Codeblock } from "../../../../../components/Codeblock/Codeblock";
 
 <ArticleSection name="Take" id="take" level="h2" />
 
@@ -26,7 +25,6 @@ The accounts needed in this context are:
 
 And with all the constraint it will look something like this:
 
-<Codeblock lang="rust">
   ```rust
 #[derive(Accounts)]
 pub struct Take<'info> {
@@ -85,13 +83,11 @@ pub struct Take<'info> {
     pub system_program: Program<'info, System>,
 }
   ```
-</Codeblock>
 
 ### Logic 
 
 In the logic we then start by transferring the tokens from the `taker_ata_b` to the `maker_ata_b`; we then move onto transferring the tokens from the `vault` to the `taker_ata_a` before closing the now empty vault like this:
 
-<Codeblock lang="rust">
 ```rust
 impl<'info> Take<'info> {
     fn transfer_to_maker(&mut self) -> Result<()> {
@@ -152,11 +148,9 @@ impl<'info> Take<'info> {
     }
 }
 ```
-</Codeblock>
 
 We now create the `handler` function and this time luckily we don't need to perform any additional checks so it will look like this:
 
-<Codeblock lang="rust">
 ```rust
 pub fn handler(ctx: Context<Take>) -> Result<()> {
     // Transfer Token B to Maker
@@ -168,4 +162,3 @@ pub fn handler(ctx: Context<Take>) -> Result<()> {
     Ok(())
 }
 ```
-</Codeblock>

--- a/src/app/content/challenges/anchor-escrow/fr/challenge.mdx
+++ b/src/app/content/challenges/anchor-escrow/fr/challenge.mdx
@@ -1,5 +1,4 @@
 import { ArticleSection } from "../../../../components/ArticleSection/ArticleSection";
-import { Codeblock } from "../../../../components/Codeblock/Codeblock";
 
 ![Anchor Escrow Challenge](/graphics/challenge-banners/anchor-escrow.png)
 
@@ -22,21 +21,17 @@ Dans ce challenge, nous allons mettre en œuvre ce concept à travers trois inst
 
 Commençons par créer un nouvel espace de travail Anchor :
 
-<Codeblock lang="terminal">
 ```bash
 anchor init blueshift_anchor_escrow
 cd blueshift_anchor_escrow
 ```
-</Codeblock>
 
 Nous continuons ensuite en activant `init-if-needed` sur la crate `anchor-lang` et en ajoutant la crate `anchor-spl` :
 
-<Codeblock lang="terminal">
 ```bash
 cargo add anchor-lang --features init-if-needed
 cargo add anchor-spl
 ```
-</Codeblock>
 
 Puisque nous utilisons `anchor-spl`, nous devons aussi mettre à jour le fichier `Cargo.toml` pour inclure `anchor-spl/idl-build` dans la fonctionnalité `idl-build`.
 
@@ -74,7 +69,6 @@ src
 
 Le fichier `lib.rs` ressemblera donc à peu près à ceci :
 
-<Codeblock lang="rust">
 ```rust
 use anchor_lang::prelude::*;
 
@@ -105,7 +99,6 @@ pub mod blueshift_anchor_escrow {
     }
 }
 ```
-</Codeblock>
 
 Comme vous le voyez, nous avons implémenté un discriminateur personnalisé pour les instructions. Veillez donc à utiliser Anchor version 0.31.0 ou plus récente.
 
@@ -113,7 +106,6 @@ Comme vous le voyez, nous avons implémenté un discriminateur personnalisé pou
 
 Nous allons nous rendre dans le fichier `state.rs` où se trouvent toutes les données de notre `Escrow`. Pour ce faire, nous allons lui donner un discriminateur personnalisé et envelopper la structure dans la macro `#[account]` comme ceci :
 
-<Codeblock lang="rust">
 ```rust
 use anchor_lang::prelude::*;
 
@@ -128,7 +120,6 @@ use anchor_lang::prelude::*;
     pub bump: u8,
 }
   ```
-</Codeblock>
 
 Rôle de chaque champ :
 - **seed**: Nombre aléatoire utilisé lors du processus de dérivation des seeds pour qu'un créateur puisse ouvrir plusieurs escrows avec la même paire de jetons. Il est stocké on-chain pour que nous puissions toujours retrouver le PDA.
@@ -145,7 +136,6 @@ Nous terminons en ajoutant la macro `#[derive(InitSpace)]` afin de ne pas avoir 
 
 Nous pouvons maintenant passer au fichier `errors.rs` où nous allons ajouter quelques erreurs que nous utiliserons plus tard : 
 
-<Codeblock lang="rust">
 ```rust
 use anchor_lang::prelude::*;
 
@@ -161,6 +151,5 @@ pub enum EscrowError {
     InvalidMintB,
 }
 ```
-</Codeblock>
 
 Chaque enum correspond à un message clair et lisible par l'homme qu'Anchor affichera chaque fois qu'une contrainte ou un `require !()` échouera.

--- a/src/app/content/challenges/anchor-escrow/fr/pages/make.mdx
+++ b/src/app/content/challenges/anchor-escrow/fr/pages/make.mdx
@@ -1,5 +1,4 @@
 import { ArticleSection } from "../../../../../components/ArticleSection/ArticleSection";
-import { Codeblock } from "../../../../../components/Codeblock/Codeblock";
 
 <ArticleSection name="Créer" id="make" level="h2" />
 
@@ -23,7 +22,6 @@ Les comptes nécessaires dans ce contexte sont :
 
 Et avec toutes les contraintes, cela ressemblera à quelque chose comme ceci :
 
-<Codeblock lang="rust">
 ```rust
 #[instruction(seed: u64)]
 pub struct Make<'info> {
@@ -69,7 +67,6 @@ pub struct Make<'info> {
     pub system_program: Program<'info, System>,
 }
 ```
-</Codeblock>
 
 **Remarque** : Puisque nous ne fournissons qu'un seul `token_program`, pour s'assurer que le CPI n'échoue pas dans l'instruction `take` (dans laquelle nous effectuons un transfert avec les deux mints) nous devons vérifier que les deux mints sont la propriété du même programme.
 
@@ -79,7 +76,6 @@ Après avoir initialisé les Comptes, nous pouvons enfin gérer la logique en cr
 
 Nous commençons par remplir l'`Escrow` en utilisant l'aide `set_inner()`, puis nous déposons les tokens via le CPI `transfer` :
 
-<Codeblock lang="rust">
 ```rust
 impl<'info> Make<'info> {
     /// # Create the Escrow
@@ -116,7 +112,6 @@ impl<'info> Make<'info> {
     }
 }
 ```
-</Codeblock>
 
 Nous pouvons constater qu'Anchor nous aide de multiples façons :
 - `set_inner()`: garantit que tous les champs sont remplis.
@@ -124,7 +119,6 @@ Nous pouvons constater qu'Anchor nous aide de multiples façons :
 
 Et maintenant, nous pouvons créer une fonction `handler` où nous effectuons quelques vérifications avant d'utiliser les fonctions d'aide :
 
-<Codeblock lang="rust">
 ```rust
 pub fn handler(ctx: Context<Make>, seed: u64, receive: u64, amount: u64) -> Result<()> {
     // Validate the amount
@@ -140,7 +134,6 @@ pub fn handler(ctx: Context<Make>, seed: u64, receive: u64, amount: u64) -> Resu
     Ok(())
 }
   ```
-</Codeblock>
 
 Ici, nous ajoutons deux contrôles de validation. Un sur l'argument `amount` et un sur l'argument `receive` pour s'assurer que nous ne passons pas une valeur nulle pour l'un ou l'autre.
 

--- a/src/app/content/challenges/anchor-escrow/fr/pages/refund.mdx
+++ b/src/app/content/challenges/anchor-escrow/fr/pages/refund.mdx
@@ -1,5 +1,4 @@
 import { ArticleSection } from "../../../../../components/ArticleSection/ArticleSection";
-import { Codeblock } from "../../../../../components/Codeblock/Codeblock";
 
 <ArticleSection name="Accepter" id="refund" level="h2" />
 
@@ -33,7 +32,6 @@ Sachez simplement qu'une fois cette opération effectuée, l'offre est annulée,
 
 Maintenant que nous avons créé toutes les fonctions dans les différentes instructions, nous pouvons enfin compléter le fichier `lib.rs` avec toutes les fonctions que nous avons créées :
 
-<Codeblock lang="rust">
 ```rust
 #[program]
 pub mod blueshift_anchor_escrow {
@@ -52,7 +50,6 @@ pub mod blueshift_anchor_escrow {
     }
 }
 ```
-</Codeblock>
 
 <ArticleSection name="Conclusion" id="conclusion" level="h2" />
 

--- a/src/app/content/challenges/anchor-escrow/fr/pages/take.mdx
+++ b/src/app/content/challenges/anchor-escrow/fr/pages/take.mdx
@@ -1,5 +1,4 @@
 import { ArticleSection } from "../../../../../components/ArticleSection/ArticleSection";
-import { Codeblock } from "../../../../../components/Codeblock/Codeblock";
 
 <ArticleSection name="Accepter" id="take" level="h2" />
 
@@ -26,7 +25,6 @@ Les comptes nécessaires dans ce contexte sont :
 
 Et avec toutes les contraintes, cela ressemblera à quelque chose comme ceci :
 
-<Codeblock lang="rust">
   ```rust
 #[derive(Accounts)]
 pub struct Take<'info> {
@@ -85,13 +83,11 @@ pub struct Take<'info> {
     pub system_program: Program<'info, System>,
 }
   ```
-</Codeblock>
 
 ### Logique
 
 Dans la logique, nous commençons par transférer les jetons de `taker_ata_b` à `maker_ata_b`. Nous transférons ensuite les jetons du `vault` vers le `taker_ata_a` avant de fermer le vault désormais vide :
 
-<Codeblock lang="rust">
 ```rust
 impl<'info> Take<'info> {
     fn transfer_to_maker(&mut self) -> Result<()> {
@@ -152,11 +148,9 @@ impl<'info> Take<'info> {
     }
 }
 ```
-</Codeblock>
 
 Nous créons maintenant la fonction `handler`. Cette fois, nous n'avons pas besoin d'effectuer de vérifications supplémentaires :
 
-<Codeblock lang="rust">
 ```rust
 pub fn handler(ctx: Context<Take>) -> Result<()> {
     // Transfer Token B to Maker
@@ -168,4 +162,3 @@ pub fn handler(ctx: Context<Take>) -> Result<()> {
     Ok(())
 }
 ```
-</Codeblock>

--- a/src/app/content/challenges/anchor-escrow/vi/challenge.mdx
+++ b/src/app/content/challenges/anchor-escrow/vi/challenge.mdx
@@ -1,5 +1,4 @@
 import { ArticleSection } from "../../../../components/ArticleSection/ArticleSection";
-import { Codeblock } from "../../../../components/Codeblock/Codeblock";
 
 ![Anchor Escrow Challenge](/graphics/challenge-banners/anchor-escrow.png)
 
@@ -23,21 +22,17 @@ Trong thử thách này, chúng ta sẽ triển khai khái niệm này thông qu
 
 Hãy bắt đầu bằng cách tạo một workspace Anchor mới:
 
-<Codeblock lang='terminal'>
   ```bash 
   anchor init blueshift_anchor_escrow 
   cd blueshift_anchor_escrow 
   ```
-</Codeblock>
 
 Sau đó chúng ta tiếp tục bằng cách kích hoạt `init-if-needed` trên crate `anchor-lang` và thêm crate `anchor-spl`:
 
-<Codeblock lang='terminal'>
   ```bash 
   cargo add anchor-lang --features init-if-needed 
   cargo add anchor-spl
   ```
-</Codeblock>
 
 Vì chúng ta đang sử dụng `anchor-spl`, chúng ta cũng cần cập nhật file `programs/blueshift_anchor_escrow/Cargo.toml` để bao gồm `anchor-spl/idl-build` trong tính năng `idl-build`.
 
@@ -75,7 +70,6 @@ src
 
 Trong đó `lib.rs` sẽ trông như thế này:
 
-<Codeblock lang="rust">
 ```rust
 use anchor_lang::prelude::*;
 
@@ -108,7 +102,6 @@ use super::*;
 }
 
 ```
-</Codeblock>
 
 Như bạn thấy, chúng ta đã triển khai discriminator tùy chỉnh cho các lệnh. Vì vậy hãy đảm bảo sử dụng phiên bản anchor 0.31.0 hoặc mới hơn.
 
@@ -116,7 +109,6 @@ Như bạn thấy, chúng ta đã triển khai discriminator tùy chỉnh cho c�
 
 Chúng ta sẽ chuyển đến `state.rs` nơi tất cả dữ liệu cho `Escrow` của chúng ta tồn tại. Để làm điều này, chúng ta sẽ cung cấp cho nó một discriminator tùy chỉnh và bao bọc struct vào macro `#[account]` như thế này:
 
-<Codeblock lang="rust">
 ```rust
 use anchor_lang::prelude::*;
 
@@ -132,7 +124,6 @@ pub struct Escrow {
 }
 ```
 
-</Codeblock>
 
 Ý nghĩa của từng trường:
 
@@ -150,7 +141,6 @@ Chúng ta kết thúc bằng cách thêm macro `#[derive(InitSpace)]` để khô
 
 Bây giờ chúng ta có thể chuyển đến file `errors.rs` nơi chúng ta sẽ thêm một số thông báo lỗi mà chúng ta sẽ sử dụng sau đó như thế này:
 
-<Codeblock lang="rust">
 ```rust
 use anchor_lang::prelude::*;
 
@@ -166,6 +156,5 @@ pub enum EscrowError {
     InvalidMintB,
 }
 ```
-</Codeblock>
 
 Mỗi enum ánh xạ đến một thông báo rõ ràng, dễ đọc mà Anchor sẽ hiển thị bất cứ khi nào một ràng buộc hoặc `require!()` không được đáp ứng.

--- a/src/app/content/challenges/anchor-escrow/vi/pages/make.mdx
+++ b/src/app/content/challenges/anchor-escrow/vi/pages/make.mdx
@@ -1,5 +1,4 @@
 import { ArticleSection } from "../../../../../components/ArticleSection/ArticleSection";
-import { Codeblock } from "../../../../../components/Codeblock/Codeblock";
 
 <ArticleSection name="Make" id="make" level="h2" />
 
@@ -25,7 +24,6 @@ Các tài khoản cần thiết trong ngữ cảnh này là:
 
 Và với tất cả các ràng buộc, nó sẽ trông như thế này:
 
-<Codeblock lang="rust">
 ```rust
 #[derive(Accounts)]
 #[instruction(seed: u64)]
@@ -74,7 +72,6 @@ pub struct Make<'info> {
 }
 
 ```
-</Codeblock>
 
 **Lưu ý**: instruction này chỉ truyền vào 1 token program. Bởi vì để chuyển token cho cả hai mint, chúng ta phải đảm bảo rằng cả 2 mint đều được sở hữu bởi cùng token program (SPL Token hoặc Token-2022), hoặc lời gọi CPI sẽ thất bại.
 
@@ -84,7 +81,6 @@ Sau khi khởi tạo các Tài khoản, cuối cùng chúng ta có thể xử l�
 
 Chúng ta bắt đầu bằng cách điền vào `Escrow` bằng helper `set_inner()`, và sau đó chuyển sang gửi token thông qua CPI `transfer` như thế này:
 
-<Codeblock lang="rust">
 ```rust
 impl<'info> Make<'info> {
     /// # Create the Escrow
@@ -122,7 +118,6 @@ impl<'info> Make<'info> {
 }
 ```
 
-</Codeblock>
 
 Chúng ta có thể thấy rằng Anchor giúp chúng ta bằng nhiều cách:
 
@@ -131,7 +126,6 @@ Chúng ta có thể thấy rằng Anchor giúp chúng ta bằng nhiều cách:
 
 Và bây giờ chúng ta có thể chuyển sang tạo hàm `handler` nơi chúng ta thực hiện một số kiểm tra trước khi sử dụng các hàm hỗ trợ, như thế này:
 
-<Codeblock lang="rust">
 ```rust
 pub fn handler(ctx: Context<Make>, seed: u64, receive: u64, amount: u64) -> Result<()> {
     // Validate the amount
@@ -149,7 +143,6 @@ pub fn handler(ctx: Context<Make>, seed: u64, receive: u64, amount: u64) -> Resu
 }
 
 ```
-</Codeblock>
 
 Ở đây chúng ta thêm hai kiểm tra xác thực cho các đối số; một cho `amount` và một cho `receive` để đảm bảo chúng ta không truyền giá trị zero cho cả hai.
 

--- a/src/app/content/challenges/anchor-escrow/vi/pages/refund.mdx
+++ b/src/app/content/challenges/anchor-escrow/vi/pages/refund.mdx
@@ -1,5 +1,4 @@
 import { ArticleSection } from "../../../../../components/ArticleSection/ArticleSection";
-import { Codeblock } from "../../../../../components/Codeblock/Codeblock";
 
 <ArticleSection name="Refund" id="refund" level="h2" />
 
@@ -35,7 +34,6 @@ Chỉ cần biết rằng một khi điều này thực thi, đề nghị sẽ v
 
 Bây giờ chúng ta đã tạo tất cả các hàm trong các lệnh khác nhau, cuối cùng chúng ta có thể điền vào `lib.rs` với tất cả các hàm mà chúng ta đã tạo; như thế này:
 
-<Codeblock lang="rust">
 ```rust
 #[program]
 pub mod blueshift_anchor_escrow {
@@ -56,7 +54,6 @@ pub mod blueshift_anchor_escrow {
 }
 
 ```
-</Codeblock>
 
 <ArticleSection name="Kết luận" id="conclusion" level="h2" />
 

--- a/src/app/content/challenges/anchor-escrow/vi/pages/take.mdx
+++ b/src/app/content/challenges/anchor-escrow/vi/pages/take.mdx
@@ -1,5 +1,4 @@
 import { ArticleSection } from '../../../../../components/ArticleSection/ArticleSection';
-import { Codeblock } from '../../../../../components/Codeblock/Codeblock';
 
 <ArticleSection name="Take" id="take" level="h2" />
 
@@ -28,7 +27,6 @@ Các tài khoản cần thiết trong ngữ cảnh này là:
 
 Và với tất cả các ràng buộc, nó sẽ trông như thế này:
 
-<Codeblock lang="rust">
   ```rust
 #[derive(Accounts)]
 pub struct Take<'info> {
@@ -89,13 +87,11 @@ pub struct Take<'info> {
 }
 
 ```
-</Codeblock>
 
 ### Logic
 
 Trong logic, chúng ta bắt đầu bằng cách chuyển token từ `taker_ata_b` đến `maker_ata_b`; sau đó chúng ta chuyển sang chuyển token từ `vault` đến `taker_ata_a` trước khi đóng vault hiện đã trống như thế này:
 
-<Codeblock lang="rust">
 ```rust
 impl<'info> Take<'info> {
   fn transfer_to_maker(&mut self) -> Result<()> {
@@ -157,11 +153,9 @@ impl<'info> Take<'info> {
 }
 ```
 
-</Codeblock>
 
 Bây giờ chúng ta tạo hàm `handler` và lần này may mắn là chúng ta không cần thực hiện thêm kiểm tra nào nên nó sẽ trông như thế này:
 
-<Codeblock lang="rust">
 ```rust
 pub fn handler(ctx: Context<Take>) -> Result<()> {
     // Transfer Token B to Maker
@@ -175,4 +169,3 @@ pub fn handler(ctx: Context<Take>) -> Result<()> {
 }
 
 ```
-</Codeblock>

--- a/src/app/content/challenges/anchor-flash-loan/en/challenge.mdx
+++ b/src/app/content/challenges/anchor-flash-loan/en/challenge.mdx
@@ -1,5 +1,4 @@
 import { ArticleSection } from "../../../../components/ArticleSection/ArticleSection";
-import { Codeblock } from "../../../../components/Codeblock/Codeblock";
 
 # Anchor Flash Loan
 
@@ -26,21 +25,17 @@ If you're new to instruction introspection, we recommend starting with the[ Inst
 
 Before you begin, ensure you have Rust and Anchor installed. If you need setup instructions, refer to the [official anchor documentation](https://www.anchor-lang.com/docs/installation). Then in your terminal run:
 
-<Codeblock lang="terminal">
 ```bash
 anchor init blueshift_anchor_flash_loan
 ```
-</Codeblock>
 
 Add the required dependencies:
 - `anchor-spl`: Provides utilities for working with SPL tokens (Solana's token standard)
 
-<Codeblock lang="terminal">
 ```bash
 cd blueshift_anchor_flash_loan
 cargo add anchor-spl
 ```
-</Codeblock>
 
 Now you're ready to dive into building your flash loan program!
 
@@ -50,7 +45,6 @@ Let's build the foundation of our flash loan program by setting up the basic str
 
 We'll implement everything in `lib.rs` since we only have two instructions that share the same account structure. Here's our starting template with all the essential components:
 
-<Codeblock lang="rust">
 ```rust
 use anchor_lang::prelude::*;
 use anchor_spl::{
@@ -94,7 +88,6 @@ pub enum ProtocolError {
   // error enum..
 }
 ```
-</Codeblock>
 
 **Note**: remember to change the program ID to `22222222222222222222222222222222222222222222` since we use this under the hood to test your program.
 
@@ -113,7 +106,6 @@ Our `Loan` account struct needs these components:
 
 Here's how we define the account struct:
 
-<Codeblock lang="rust">
 ```rust
 #[derive(Accounts)]
 pub struct Loan<'info> {
@@ -148,7 +140,6 @@ pub struct Loan<'info> {
   pub system_program: Program<'info, System>
 }
 ```
-</Codeblock>
 
 As you can see, the accounts needed for this instruction and their constraint are quite straightforward:
 - `protocol`: uses `seeds = [b"protocol".as_ref()]` to create a deterministic address that owns all protocol liquidity. This ensures only our program can control these funds.
@@ -160,7 +151,6 @@ As you can see, the accounts needed for this instruction and their constraint ar
 
 Flash loans require precise validation at multiple steps, so we need comprehensive error handling. Here's our complete error enum:
 
-<Codeblock lang="rust">
 ```rust
 #[error_code]
 pub enum ProtocolError {
@@ -188,7 +178,6 @@ pub enum ProtocolError {
     Overflow,
 }
 ```
-</Codeblock>
 
 With this foundation in place, we're ready to implement the core logic for our flash loan instructions. The account structure ensures proper token handling, while the error system provides clear feedback for debugging and security validation.
 

--- a/src/app/content/challenges/anchor-flash-loan/en/pages/borrow.mdx
+++ b/src/app/content/challenges/anchor-flash-loan/en/pages/borrow.mdx
@@ -8,7 +8,6 @@ The borrow instruction is the first half of our flash loan system. It performs t
 
 First, we implement the actual transfer of funds with proper validation:
 
-<Codeblock lang="rust">
 ```rust
 // Make sure we're not sending in an invalid amount that can crash our Protocol
 require!(borrow_amount > 0, ProtocolError::InvalidAmount);
@@ -34,7 +33,6 @@ transfer(
     borrow_amount
 )?;
 ```
-</Codeblock>
 
 This code ensures we're transferring a valid amount and uses the protocol's Program Derived Address (PDA) to authorize the transfer.
 
@@ -45,7 +43,6 @@ Now comes the security-critical part: using instruction introspection to verify 
 We start by accessing the `instructions` sysvar, which contains information about all instructions in the current transaction:
 
 
-<Codeblock lang="rust">
 ```rust
 /*
     Instruction Introspection
@@ -56,7 +53,6 @@ We start by accessing the `instructions` sysvar, which contains information abou
 
 let ixs = ctx.accounts.instructions.to_account_info();
 ```
-</Codeblock>
 
 Finally, we perform the most critical check: ensuring that the last instruction in the transaction is a valid repayment instruction:
 - We start by checking the position of the borrow instruction to make sure it's the only one
@@ -64,7 +60,6 @@ Finally, we perform the most critical check: ensuring that the last instruction 
 - Then we verify that it's the repay instruction by verifying the program ID and the discriminator of the instruction
 - We finish by verifying that the ATAs passed in the repay instruction are the same that we're passing in our `Borrow` instruction
 
-<Codeblock lang="rust">
 ```rust
 /*
     Repay Instruction Check
@@ -95,4 +90,3 @@ if let Ok(repay_ix) = load_instruction_at_checked(len as usize - 1, &ixs) {
     return Err(ProtocolError::MissingRepayIx.into());
 }
 ```
-</Codeblock>

--- a/src/app/content/challenges/anchor-flash-loan/en/pages/repay.mdx
+++ b/src/app/content/challenges/anchor-flash-loan/en/pages/repay.mdx
@@ -8,7 +8,6 @@ The repay instruction completes our flash loan cycle by ensuring the borrowed fu
 
 First, we need to examine the first instruction in the transaction to extract the original loan amount:
 
-<Codeblock lang="rust">
 ```rust
 let ixs = ctx.accounts.instructions.to_account_info();
 
@@ -24,7 +23,6 @@ if let Ok(borrow_ix) = load_instruction_at_checked(0, &ixs) {
     return Err(ProtocolError::MissingBorrowIx.into());
 }
 ```
-</Codeblock>
 
 > We're not checking that this is the actual `borrow_ix` using the program ID and discriminator because it doesn't matter if they actually construct a "fake" instruction; it's safe for the protocol since it's just getting paid. At the same time, if we loaned the money we know that it's going to be the first instruction and that the `amount_borrowed` will be there.
 
@@ -32,7 +30,6 @@ if let Ok(borrow_ix) = load_instruction_at_checked(0, &ixs) {
 
 Next, we calculate the protocol fee and transfer the total amount back:
 
-<Codeblock lang="rust">
 ```rust
 // Add the fee to the amount borrowed (In our case we hardcoded it to 500 basis point)
 let fee = (amount_borrowed as u128).checked_mul(500).unwrap().checked_div(10_000).ok_or(ProtocolError::Overflow)? as u64;
@@ -48,6 +45,5 @@ transfer(
     amount_borrowed
 )?;
 ```
-</Codeblock>
 
 Our fee is hard coded to 500 basis point, and we perform "checked" math to make sure that the amount doesn't overflow which could be exploited with very large numbers. Additionally, we convert the amount to `u128` for the multiplication to prevent intermediate overflow, then we safely cast back to `u64`

--- a/src/app/content/challenges/anchor-flash-loan/fr/challenge.mdx
+++ b/src/app/content/challenges/anchor-flash-loan/fr/challenge.mdx
@@ -1,5 +1,4 @@
 import { ArticleSection } from "../../../../components/ArticleSection/ArticleSection";
-import { Codeblock } from "../../../../components/Codeblock/Codeblock";
 
 # Prêt Flash avec Anchor
 
@@ -24,21 +23,17 @@ Si vous êtes novice en matière d'introspection des instructions, nous vous rec
 
 Avant de commencer, assurez-vous que Rust et Anchor sont installés. Si vous avez besoin d'instructions d'installation, consultez la [documentation officielle d'Anchor](https://www.anchor-lang.com/docs/installation). Ensuite, exécutez dans votre terminal :
 
-<Codeblock lang="terminal">
 ```bash
 anchor init blueshift_anchor_flash_loan
 ```
-</Codeblock>
 
 Ajouter les dépendances nécessaires :
 - `anchor-spl`: Fournit des utilitaires pour travailler avec les jetons SPL (la norme de jetons de Solana)
 
-<Codeblock lang="terminal">
 ```bash
 cd blueshift_anchor_flash_loan
 cargo add anchor-spl
 ```
-</Codeblock>
 
 Vous êtes maintenant prêt à vous lancer dans la création de votre programme de prêts flash !
 
@@ -48,7 +43,6 @@ Posons les bases de notre programme de prêt flash en mettant en place la struct
 
 Nous allons tout implémenter dans `lib.rs` puisque nous n'avons que deux instructions qui partagent la même structure de compte. Voici notre modèle de départ avec tous les composants essentiels :
 
-<Codeblock lang="rust">
 ```rust
 use anchor_lang::prelude::*;
 use anchor_spl::{
@@ -92,7 +86,6 @@ pub enum ProtocolError {
   // error enum..
 }
 ```
-</Codeblock>
 
 **Remarque** : n'oubliez pas de changer l'ID du programme en `22222222222222222222222222222222222222222222` puisque nous l'utilisons pour tester votre programme.
 
@@ -111,7 +104,6 @@ Notre structure de compte `Loan` a besoin de ces composants :
 
 Voici comment nous définissons la structure de compte :
 
-<Codeblock lang="rust">
 ```rust
 #[derive(Accounts)]
 pub struct Loan<'info> {
@@ -146,7 +138,6 @@ pub struct Loan<'info> {
   pub system_program: Program<'info, System>
 }
 ```
-</Codeblock>
 
 Comme vous pouvez le constater, les comptes nécessaires à cette instruction et leur contrainte sont assez simples :
 - `protocol`: utilise `seeds = [b"protocol".as_ref()]` pour créer une adresse déterministe qui possède toutes les liquidités du protocole. Cela garantit que seul notre programme peut contrôler ces fonds.
@@ -158,7 +149,6 @@ Comme vous pouvez le constater, les comptes nécessaires à cette instruction et
 
 Les prêts flash nécessitent une validation rigoureuse à plusieurs étapes, d'où la nécessité d'une bonne gestion des erreurs. Voici notre liste complète d'erreurs :
 
-<Codeblock lang="rust">
 ```rust
 #[error_code]
 pub enum ProtocolError {
@@ -186,7 +176,6 @@ pub enum ProtocolError {
     Overflow,
 }
 ```
-</Codeblock>
 
 Ces bases étant posées, nous sommes prêts à implémenter la logique de base de nos instructions. La structure de compte garantit une bonne gestion des jetons, tandis que le système d'erreur fournit un retour d'information clair pour le débogage et la validation de la sécurité.
 

--- a/src/app/content/challenges/anchor-flash-loan/fr/pages/borrow.mdx
+++ b/src/app/content/challenges/anchor-flash-loan/fr/pages/borrow.mdx
@@ -8,7 +8,6 @@ L'instruction `borrow` est la première partie de notre système de prêt flash.
 
 Tout d'abord, nous implémentons le transfert de fonds avec une validation adéquate :
 
-<Codeblock lang="rust">
 ```rust
 // Make sure we're not sending in an invalid amount that can crash our Protocol
 require!(borrow_amount > 0, ProtocolError::InvalidAmount);
@@ -34,7 +33,6 @@ transfer(
     borrow_amount
 )?;
 ```
-</Codeblock>
 
 Ce code s'assure que le montant transféré est valide et utilise l'Adresse Dérivée de Programme (PDA) du protocole pour autoriser le transfert.
 
@@ -45,7 +43,6 @@ Vient maintenant la partie critique de la sécurité : l'utilisation de l'intros
 Nous commençons par accéder au sysvar `instructions` qui contient les informations sur toutes les instructions de la transaction actuelle :
 
 
-<Codeblock lang="rust">
 ```rust
 /*
     Instruction Introspection
@@ -56,14 +53,12 @@ Nous commençons par accéder au sysvar `instructions` qui contient les informat
 
 let ixs = ctx.accounts.instructions.to_account_info();
 ```
-</Codeblock>
 
 Enfin, nous effectuons la vérification la plus critique : nous nous assurons que la dernière instruction de la transaction est une instruction de remboursement valide :
 - Nous commençons par vérifier le nombre d'instructions et nous nous assurons que nous chargeons la dernière instruction de la transaction
 - TNous vérifions ensuite qu'il s'agit bien de l'instruction de remboursement en vérifiant l'ID du programme et le discriminateur de l'instruction
 - Nous terminons en vérifiant que les ATAs passés dans l'instruction de remboursement sont les mêmes que ceux que nous passons dans notre instruction `Borrow`
 
-<Codeblock lang="rust">
 ```rust
 /*
     Repay Instruction Check
@@ -90,4 +85,3 @@ if let Ok(repay_ix) = load_instruction_at_checked(len as usize - 1, &ixs) {
     return Err(ProtocolError::MissingRepayIx.into());
 }
 ```
-</Codeblock>

--- a/src/app/content/challenges/anchor-flash-loan/fr/pages/repay.mdx
+++ b/src/app/content/challenges/anchor-flash-loan/fr/pages/repay.mdx
@@ -8,7 +8,6 @@ L'instruction `repay` termine notre cycle de prêt flash en garantissant que les
 
 Tout d'abord, nous devons examiner la première instruction de la transaction afin d'extraire le montant initial du prêt :
 
-<Codeblock lang="rust">
 ```rust
 let ixs = ctx.accounts.instructions.to_account_info();
 
@@ -24,7 +23,6 @@ if let Ok(borrow_ix) = load_instruction_at_checked(0, &ixs) {
     return Err(ProtocolError::MissingBorrowIx.into());
 }
 ```
-</Codeblock>
 
 > Nous ne vérifions pas qu'il s'agit bien de la vraie `borrow_ix` en utilisant l'ID du programme et le discriminateur car cela n'a pas d'importance si une personne construit une "fausse" instruction. C'est sans danger pour le protocole puisqu'il est juste payé. Par ailleurs, si nous avons prêté l'argent, nous savons qu'il s'agira de la première instruction et que le `amount_borrowed` y figurera.
 
@@ -32,7 +30,6 @@ if let Ok(borrow_ix) = load_instruction_at_checked(0, &ixs) {
 
 Ensuite, nous calculons les frais de protocole et transférons le montant total :
 
-<Codeblock lang="rust">
 ```rust
 // Add the fee to the amount borrowed (In our case we hardcoded it to 500 basis point)
 let fee = (amount_borrowed as u128).checked_mul(500).unwrap().checked_div(10_000).ok_or(ProtocolError::Overflow)? as u64;
@@ -48,6 +45,5 @@ transfer(
     amount_borrowed
 )?;
 ```
-</Codeblock>
 
 Notre commission est codée en dur à 500 points de base et nous effectuons des calculs "vérifiés" pour nous assurer que le montant ne dépasse pas, ce qui pourrait être exploité avec de très grands nombres. De plus, nous convertissons le montant en `u128` pour la multiplication afin d'éviter un dépassement intermédiaire, puis nous repassons en toute sécurité en `u64`.

--- a/src/app/content/challenges/anchor-flash-loan/vi/challenge.mdx
+++ b/src/app/content/challenges/anchor-flash-loan/vi/challenge.mdx
@@ -1,5 +1,4 @@
 import { ArticleSection } from "../../../../components/ArticleSection/ArticleSection";
-import { Codeblock } from "../../../../components/Codeblock/Codeblock";
 
 # Anchor Flash Loan
 
@@ -26,21 +25,17 @@ Nếu bạn mới làm quen với instruction introspection, chúng tôi khuyên
 
 Trước khi bắt đầu, hãy đảm bảo bạn đã cài đặt Rust và Anchor. Nếu bạn cần hướng dẫn thiết lập, hãy tham khảo [tài liệu chính thức của anchor](https://www.anchor-lang.com/docs/installation). Sau đó chạy lệnh sau trong terminal:
 
-<Codeblock lang="terminal">
 ```bash
 anchor init blueshift_anchor_flash_loan
 ```
-</Codeblock>
 
 Thêm các dependency cần thiết:
 - `anchor-spl`: Cung cấp các tiện ích để làm việc với SPL token (tiêu chuẩn token của Solana)
 
-<Codeblock lang="terminal">
 ```bash
 cd blueshift_anchor_flash_loan
 cargo add anchor-spl
 ```
-</Codeblock>
 
 Bây giờ bạn đã sẵn sàng để bắt đầu xây dựng chương trình flash loan của mình!
 
@@ -50,7 +45,6 @@ Hãy xây dựng nền tảng cho chương trình flash loan bằng cách thiế
 
 Chúng ta sẽ triển khai mọi thứ trong `lib.rs` vì chỉ có hai instruction chia sẻ cùng một cấu trúc account. Đây là template khởi đầu với tất cả các thành phần thiết yếu:
 
-<Codeblock lang="rust">
 ```rust
 use anchor_lang::prelude::*;
 use anchor_spl::{
@@ -94,7 +88,6 @@ pub enum ProtocolError {
   // error enum..
 }
 ```
-</Codeblock>
 
 **Lưu ý**: nhớ thay đổi program ID thành `22222222222222222222222222222222222222222222` vì chúng tôi sử dụng ID này để test chương trình của bạn.
 
@@ -113,7 +106,6 @@ Struct account `Loan` của chúng ta cần các thành phần sau:
 
 Đây là cách chúng ta định nghĩa account struct:
 
-<Codeblock lang="rust">
 ```rust
 #[derive(Accounts)]
 pub struct Loan<'info> {
@@ -148,7 +140,6 @@ pub struct Loan<'info> {
   pub system_program: Program<'info, System>
 }
 ```
-</Codeblock>
 
 Như bạn có thể thấy, các account cần thiết cho instruction này và các ràng buộc của chúng khá đơn giản:
 - `protocol`: sử dụng `seeds = [b"protocol".as_ref()]` để tạo một địa chỉ xác định sở hữu toàn bộ liquidity của protocol. Điều này đảm bảo chỉ chương trình của chúng ta mới có thể kiểm soát các khoản tiền này.
@@ -160,7 +151,6 @@ Như bạn có thể thấy, các account cần thiết cho instruction này và
 
 Flash loan yêu cầu validation chính xác ở nhiều bước, vì vậy chúng ta cần xử lý lỗi toàn diện. Đây là error enum hoàn chỉnh của chúng ta:
 
-<Codeblock lang="rust">
 ```rust
 #[error_code]
 pub enum ProtocolError {
@@ -188,7 +178,6 @@ pub enum ProtocolError {
     Overflow,
 }
 ```
-</Codeblock>
 
 Với nền tảng này, chúng ta sẵn sàng triển khai logic cốt lõi cho các instruction flash loan. Cấu trúc account đảm bảo xử lý token đúng cách, trong khi hệ thống lỗi cung cấp phản hồi rõ ràng cho việc debug và validation bảo mật.
 

--- a/src/app/content/challenges/anchor-flash-loan/vi/pages/borrow.mdx
+++ b/src/app/content/challenges/anchor-flash-loan/vi/pages/borrow.mdx
@@ -8,7 +8,6 @@ Instruction borrow là nửa đầu của hệ thống flash loan. Nó thực hi
 
 Đầu tiên, chúng ta triển khai việc chuyển tiền thực tế với validation phù hợp:
 
-<Codeblock lang="rust">
 ```rust
 // Make sure we're not sending in an invalid amount that can crash our Protocol
 require!(borrow_amount > 0, ProtocolError::InvalidAmount);
@@ -34,7 +33,6 @@ transfer(
     borrow_amount
 )?;
 ```
-</Codeblock>
 
 Mã này đảm bảo chúng ta đang chuyển một số tiền hợp lệ và sử dụng Program Derived Address (PDA) của protocol để ủy quyền chuyển tiền.
 
@@ -45,7 +43,6 @@ Bây giờ đến phần quan trọng về bảo mật: sử dụng instruction 
 Chúng ta bắt đầu bằng cách truy cập `instructions` sysvar, chứa thông tin về tất cả instruction trong transaction hiện tại:
 
 
-<Codeblock lang="rust">
 ```rust
 /*
     Instruction Introspection
@@ -56,14 +53,12 @@ Chúng ta bắt đầu bằng cách truy cập `instructions` sysvar, chứa th�
 
 let ixs = ctx.accounts.instructions.to_account_info();
 ```
-</Codeblock>
 
 Cuối cùng, chúng ta thực hiện kiểm tra quan trọng nhất: đảm bảo rằng instruction cuối cùng trong transaction là một instruction trả nợ hợp lệ:
 - Chúng ta bắt đầu bằng cách kiểm tra số lượng instruction và đảm bảo rằng chúng ta đang load instruction cuối cùng của transaction
 - Sau đó chúng ta xác minh rằng đó là instruction repay bằng cách kiểm tra program ID và discriminator của instruction
 - Chúng ta kết thúc bằng cách xác minh rằng các ATA được truyền trong instruction repay giống với những gì chúng ta đang truyền trong instruction `Borrow`
 
-<Codeblock lang="rust">
 ```rust
 /*
     Repay Instruction Check
@@ -90,4 +85,3 @@ if let Ok(repay_ix) = load_instruction_at_checked(len as usize - 1, &ixs) {
     return Err(ProtocolError::MissingRepayIx.into());
 }
 ```
-</Codeblock>

--- a/src/app/content/challenges/anchor-flash-loan/vi/pages/repay.mdx
+++ b/src/app/content/challenges/anchor-flash-loan/vi/pages/repay.mdx
@@ -8,7 +8,6 @@ Instruction repay hoàn thành chu kỳ flash loan bằng cách đảm bảo cá
 
 Đầu tiên, chúng ta cần kiểm tra instruction đầu tiên trong transaction để trích xuất số tiền vay gốc:
 
-<Codeblock lang="rust">
 ```rust
 let ixs = ctx.accounts.instructions.to_account_info();
 
@@ -24,7 +23,6 @@ if let Ok(borrow_ix) = load_instruction_at_checked(0, &ixs) {
     return Err(ProtocolError::MissingBorrowIx.into());
 }
 ```
-</Codeblock>
 
 > Chúng ta không kiểm tra rằng đây là `borrow_ix` thực tế bằng cách sử dụng program ID và discriminator vì không quan trọng nếu họ thực sự tạo một instruction "giả"; điều này an toàn cho protocol vì nó chỉ được trả tiền. Đồng thời, nếu chúng ta đã cho vay tiền, chúng ta biết rằng nó sẽ là instruction đầu tiên và `amount_borrowed` sẽ ở đó.
 
@@ -32,7 +30,6 @@ if let Ok(borrow_ix) = load_instruction_at_checked(0, &ixs) {
 
 Tiếp theo, chúng ta tính phí protocol và chuyển tổng số tiền trở lại:
 
-<Codeblock lang="rust">
 ```rust
 // Add the fee to the amount borrowed (In our case we hardcoded it to 500 basis point)
 let fee = (amount_borrowed as u128).checked_mul(500).unwrap().checked_div(10_000).ok_or(ProtocolError::Overflow)? as u64;
@@ -48,6 +45,5 @@ transfer(
     amount_borrowed
 )?;
 ```
-</Codeblock>
 
 Phí của chúng ta được hardcode thành 500 basis point, và chúng ta thực hiện phép toán "checked" để đảm bảo rằng số tiền không bị overflow có thể bị khai thác với các số rất lớn. Ngoài ra, chúng ta chuyển đổi số tiền thành kiểu `u128` cho phép nhân để ngăn overflow trung gian, sau đó chúng ta safely cast trở lại kiểu `u64`

--- a/src/app/content/challenges/anchor-vault/en/challenge.mdx
+++ b/src/app/content/challenges/anchor-vault/en/challenge.mdx
@@ -1,5 +1,4 @@
 import { ArticleSection } from "../../../../components/ArticleSection/ArticleSection";
-import { Codeblock } from "../../../../components/Codeblock/Codeblock";
 
 ![Anchor Vault Challenge](/graphics/challenge-banners/anchor-vault.png)
 
@@ -13,11 +12,9 @@ In this challenge, we'll build a simple lamport vault that demonstrates how to w
 
 Before you begin, be sure Rust and Anchor are installed (see the [official documentation](https://www.anchor-lang.com/docs/installation) if you need a refresher). Then in your terminal run:
 
-<Codeblock lang="terminal">
 ```bash
 anchor init blueshift_anchor_vault
 ```
-</Codeblock>
 
 We don't need any additional crate for this challenge, so you can now open the newly generated folder, and you're ready to start coding!
 
@@ -25,7 +22,6 @@ We don't need any additional crate for this challenge, so you can now open the n
 
 Let's start with the basic program structure. We'll implement everything in `lib.rs` since this is a straightforward program. Here's the initial template with the core components we'll need:
 
-<Codeblock lang="rust">
 ```rust
 declare_id!("22222222222222222222222222222222222222222222");
 
@@ -62,7 +58,6 @@ pub enum VaultError {
     // error enum
 }
 ```
-</Codeblock>
 
 **Note**: remember to change the program ID to `22222222222222222222222222222222222222222222` since we use this under the hood to test your program.
 
@@ -77,7 +72,6 @@ The `VaultAction` account struct will need to have:
 
 Here's how we define the account struct:
 
-<Codeblock lang="rust">
 ```rust
 #[derive(Accounts)]
 pub struct VaultAction<'info> {
@@ -92,7 +86,6 @@ pub struct VaultAction<'info> {
     pub system_program: Program<'info, System>,
 }
 ```
-</Codeblock>
 
 Let's break down each account constraint:
 
@@ -110,7 +103,6 @@ We don't need a lot of errors for this small programs, so we're just going to cr
 
 It will look something like this: 
 
-<Codeblock lang="rust">
 ```rust
 #[error_code]
 pub enum VaultError {
@@ -120,7 +112,6 @@ pub enum VaultError {
     InvalidAmount,
 }
 ```
-</Codeblock>
 
 <ArticleSection name="Deposit" id="deposit" level="h2" />
 
@@ -131,7 +122,6 @@ The deposit instruction performs the following steps:
 
 Let's implement these checks first:
 
-<Codeblock lang="rust">
 ```rust
 // Check if vault is empty
 require_eq!(ctx.accounts.vault.lamports(), 0, VaultError::VaultAlreadyExists);
@@ -139,7 +129,6 @@ require_eq!(ctx.accounts.vault.lamports(), 0, VaultError::VaultAlreadyExists);
 // Ensure amount exceeds rent-exempt minimum
 require_gt!(amount, Rent::get()?.minimum_balance(0), VaultError::InvalidAmount);
 ```
-</Codeblock>
 
 The two `require` macros act like custom guard clauses:
 - `require_eq!` confirms the vault is empty (preventing double deposits).
@@ -147,7 +136,6 @@ The two `require` macros act like custom guard clauses:
 
 Once the checks pass, Anchor's System Program helper calls the `Transfer` CPI like this:
 
-<Codeblock lang="rust">
 ```rust
 use anchor_lang::system_program::{transfer, Transfer};
 
@@ -162,7 +150,6 @@ transfer(
     amount,
 )?;
 ```
-</Codeblock>
 
 <ArticleSection name="Withdraw" id="withdraw" level="h2" />
 
@@ -173,16 +160,13 @@ The withdraw instruction performs the following steps:
 
 First, let's check if the vault has any lamports to withdraw:
 
-<Codeblock lang="rust">
 ```rust
 // Check if vault has any lamports
 require_neq!(ctx.accounts.vault.lamports(), 0, VaultError::InvalidAmount);
 ```
-</Codeblock>
 
 Then, we need to create the PDA signer seeds and perform the transfer:
 
-<Codeblock lang="rust">
 ```rust
 // Create PDA signer seeds
 let signer_key = ctx.accounts.signer.key();
@@ -201,7 +185,6 @@ transfer(
     ctx.accounts.vault.lamports()
 )?;
 ```
-</Codeblock>
 
 The security of this withdrawal is guaranteed by two factors:
 1. The vault's PDA is derived using the signer's public key, ensuring only the original depositor can withdraw
@@ -213,11 +196,9 @@ You can now test your program against our unit tests and claim your NFTs!
 
 Start by building your program using the following command in your terminal
 
-<Codeblock lang="terminal">
 ```bash
 anchor build
 ```
-</Codeblock>
 
 This generated a `.so` file directly in your `target/deploy` folder. 
 

--- a/src/app/content/challenges/anchor-vault/fr/challenge.mdx
+++ b/src/app/content/challenges/anchor-vault/fr/challenge.mdx
@@ -1,5 +1,4 @@
 import { ArticleSection } from "../../../../components/ArticleSection/ArticleSection";
-import { Codeblock } from "../../../../components/Codeblock/Codeblock";
 
 ![Anchor Vault Challenge](/graphics/challenge-banners/anchor-vault.png)
 
@@ -13,11 +12,9 @@ Dans ce challenge, nous allons créer un vault à lamport simple qui montre comm
 
 Avant de commencer, assurez-vous que Rust et Anchor sont installés (voir la [documentation officielle](https://www.anchor-lang.com/docs/installation) si vous avez besoin d'un rappel). Ensuite, exécutez dans votre terminal :
 
-<Codeblock lang="terminal">
 ```bash
 anchor init blueshift_anchor_vault
 ```
-</Codeblock>
 
 Nous n'avons pas besoin de crate supplémentaire pour ce challenge donc vous pouvez maintenant ouvrir le dossier précédemment créé et commencer à coder !
 
@@ -25,7 +22,6 @@ Nous n'avons pas besoin de crate supplémentaire pour ce challenge donc vous pou
 
 Commençons par la structure de base du programme. Nous allons tout implémenter dans `lib.rs` puisque c'est un programme simple. Voici le modèle de départ avec les composants essentiels dont nous aurons besoin :
 
-<Codeblock lang="rust">
 ```rust
 declare_id!("22222222222222222222222222222222222222222222");
 
@@ -62,7 +58,6 @@ pub enum VaultError {
     // error enum
 }
 ```
-</Codeblock>
 
 **Remarque** : n'oubliez pas de changer l'ID du programme en `22222222222222222222222222222222222222222222` puisque nous l'utilisons pour tester votre programme.
 
@@ -77,7 +72,6 @@ La structure de compte `VaultAction` devra avoir :
 
 Voici comment nous définissons la structure du compte :
 
-<Codeblock lang="rust">
 ```rust
 #[derive(Accounts)]
 pub struct VaultAction<'info> {
@@ -92,7 +86,6 @@ pub struct VaultAction<'info> {
     pub system_program: Program<'info, System>,
 }
 ```
-</Codeblock>
 
 Détaillons les contraintes de chaque compte :
 
@@ -110,7 +103,6 @@ Nous n'avons pas besoin de beaucoup d'erreurs pour ce petit programme, nous allo
 
 Cela ressemblera à quelque chose comme ça : 
 
-<Codeblock lang="rust">
 ```rust
 #[error_code]
 pub enum VaultError {
@@ -120,7 +112,6 @@ pub enum VaultError {
     InvalidAmount,
 }
 ```
-</Codeblock>
 
 <ArticleSection name="Dépôt" id="deposit" level="h2" />
 
@@ -131,7 +122,6 @@ L'instruction de dépôt effectue les étapes suivantes :
 
 Commençons par implémenter ces vérifications :
 
-<Codeblock lang="rust">
 ```rust
 // Check if vault is empty
 require_eq!(ctx.accounts.vault.lamports(), 0, VaultError::VaultAlreadyExists);
@@ -139,7 +129,6 @@ require_eq!(ctx.accounts.vault.lamports(), 0, VaultError::VaultAlreadyExists);
 // Ensure amount exceeds rent-exempt minimum
 require_gt!(amount, Rent::get()?.minimum_balance(0), VaultError::InvalidAmount);
 ```
-</Codeblock>
 
 Les deux macros `require` agissent comme des gardes personnalisés :
 - `require_eq!` confirme que le vault est vide (ce qui évite les doubles dépôts).
@@ -147,7 +136,6 @@ Les deux macros `require` agissent comme des gardes personnalisés :
 
 Une fois ces vérifications effectuées, la fonction d'aide Anchor du Programme Système appelle le CPI `Transfer` de la manière suivante :
 
-<Codeblock lang="rust">
 ```rust
 use anchor_lang::system_program::{transfer, Transfer};
 
@@ -162,7 +150,6 @@ transfer(
     amount,
 )?;
 ```
-</Codeblock>
 
 <ArticleSection name="Retrait" id="withdraw" level="h2" />
 
@@ -173,16 +160,13 @@ L'instruction de retrait effectue les étapes suivantes :
 
 Tout d'abord, vérifions si le vault contient des lamports à retirer :
 
-<Codeblock lang="rust">
 ```rust
 // Check if vault has any lamports
 require_neq!(ctx.accounts.vault.lamports(), 0, VaultError::InvalidAmount);
 ```
-</Codeblock>
 
 Ensuite, nous devons créer les seeds du signataire du PDA et effectuer le transfert :
 
-<Codeblock lang="rust">
 ```rust
 // Create PDA signer seeds
 let signer_key = ctx.accounts.signer.key();
@@ -201,7 +185,6 @@ transfer(
     ctx.accounts.vault.lamports()
 )?;
 ```
-</Codeblock>
 
 La sécurité de ce retrait est garantie par deux moyens :
 1. Le PDA du vault est dérivé à l'aide de la clé publique du signataire, ce qui garantit que seul le déposant initial peut effectuer un retrait
@@ -213,11 +196,9 @@ Vous pouvez maintenant tester votre programme à l'aide de nos tests unitaires e
 
 Commencez par compiler votre programme en utilisant la commande suivante dans votre terminal :
 
-<Codeblock lang="terminal">
 ```bash
 anchor build
 ```
-</Codeblock>
 
 Cela générera un fichier `.so` directement dans votre dossier `target/deploy`. 
 

--- a/src/app/content/challenges/anchor-vault/vi/challenge.mdx
+++ b/src/app/content/challenges/anchor-vault/vi/challenge.mdx
@@ -1,5 +1,4 @@
 import { ArticleSection } from "../../../../components/ArticleSection/ArticleSection";
-import { Codeblock } from "../../../../components/Codeblock/Codeblock";
 
 ![Anchor Vault Challenge](/graphics/challenge-banners/anchor-vault.png)
 
@@ -13,11 +12,9 @@ Trong thử thách này, chúng ta sẽ xây dựng một lamport vault đơn gi
 
 Trước khi bắt đầu, hãy đảm bảo Rust và Anchor đã được cài đặt (xem [tài liệu chính thức](https://www.anchor-lang.com/docs/installation) nếu bạn cần ôn lại). Sau đó chạy lệnh sau trong terminal:
 
-<Codeblock lang="terminal">
 ```bash
 anchor init blueshift_anchor_vault
 ```
-</Codeblock>
 
 Chúng ta không cần thêm crate nào cho thử thách này, vì vậy bây giờ bạn có thể mở thư mục vừa tạo và sẵn sàng bắt đầu viết mã!
 
@@ -25,7 +22,6 @@ Chúng ta không cần thêm crate nào cho thử thách này, vì vậy bây gi
 
 Hãy bắt đầu với cấu trúc chương trình cơ bản. Chúng ta sẽ triển khai mọi thứ trong `lib.rs` vì đây là một chương trình đơn giản. Đây là template ban đầu với các thành phần cốt lõi chúng ta sẽ cần:
 
-<Codeblock lang="rust">
 ```rust
 declare_id!("22222222222222222222222222222222222222222222");
 
@@ -62,7 +58,6 @@ pub enum VaultError {
     // error enum
 }
 ```
-</Codeblock>
 
 **Lưu ý**: nhớ thay đổi program ID thành `22222222222222222222222222222222222222222222` vì chúng tôi sử dụng ID này để test chương trình của bạn.
 
@@ -77,7 +72,6 @@ Struct account `VaultAction` sẽ cần có:
 
 Đây là cách chúng ta định nghĩa account struct:
 
-<Codeblock lang="rust">
 ```rust
 #[derive(Accounts)]
 pub struct VaultAction<'info> {
@@ -92,7 +86,6 @@ pub struct VaultAction<'info> {
     pub system_program: Program<'info, System>,
 }
 ```
-</Codeblock>
 
 Hãy phân tích từng ràng buộc của account:
 
@@ -110,7 +103,6 @@ Chúng ta không cần nhiều lỗi cho chương trình nhỏ này, vì vậy c
 
 Mã sẽ trông như thế này:
 
-<Codeblock lang="rust">
 ```rust
 #[error_code]
 pub enum VaultError {
@@ -120,7 +112,6 @@ pub enum VaultError {
     InvalidAmount,
 }
 ```
-</Codeblock>
 
 <ArticleSection name="Deposit" id="deposit" level="h2" />
 
@@ -131,7 +122,6 @@ Instruction deposit thực hiện các bước sau:
 
 Hãy triển khai các kiểm tra này trước:
 
-<Codeblock lang="rust">
 ```rust
 // Check if vault is empty
 require_eq!(ctx.accounts.vault.lamports(), 0, VaultError::VaultAlreadyExists);
@@ -139,7 +129,6 @@ require_eq!(ctx.accounts.vault.lamports(), 0, VaultError::VaultAlreadyExists);
 // Ensure amount exceeds rent-exempt minimum
 require_gt!(amount, Rent::get()?.minimum_balance(0), VaultError::InvalidAmount);
 ```
-</Codeblock>
 
 Hai macro `require` hoạt động như các mệnh đề ràng buộc tùy chỉnh:
 - `require_eq!` xác nhận vault trống (ngăn chặn deposit kép).
@@ -147,7 +136,6 @@ Hai macro `require` hoạt động như các mệnh đề ràng buộc tùy ch�
 
 Khi các kiểm tra thành công, helper System Program của Anchor gọi CPI `Transfer` như thế này:
 
-<Codeblock lang="rust">
 ```rust
 use anchor_lang::system_program::{transfer, Transfer};
 
@@ -162,7 +150,6 @@ transfer(
     amount,
 )?;
 ```
-</Codeblock>
 
 <ArticleSection name="Withdraw" id="withdraw" level="h2" />
 
@@ -173,16 +160,13 @@ Instruction withdraw thực hiện các bước sau:
 
 Đầu tiên, hãy kiểm tra xem vault có lamport nào để rút không:
 
-<Codeblock lang="rust">
 ```rust
 // Check if vault has any lamports
 require_neq!(ctx.accounts.vault.lamports(), 0, VaultError::InvalidAmount);
 ```
-</Codeblock>
 
 Sau đó, chúng ta cần tạo PDA signer seed và thực hiện chuyển tiền:
 
-<Codeblock lang="rust">
 ```rust
 // Create PDA signer seeds
 let signer_key = ctx.accounts.signer.key();
@@ -201,7 +185,6 @@ transfer(
     ctx.accounts.vault.lamports()
 )?;
 ```
-</Codeblock>
 
 Tính bảo mật của việc rút tiền này được đảm bảo bởi hai yếu tố:
 1. PDA của vault được tạo bằng public key của signer, đảm bảo chỉ người gửi tiền ban đầu mới có thể rút
@@ -213,11 +196,9 @@ Bây giờ bạn có thể test chương trình của mình với unit test củ
 
 Bắt đầu bằng cách build chương trình của bạn bằng lệnh sau trong terminal
 
-<Codeblock lang="terminal">
 ```bash
 anchor build
 ```
-</Codeblock>
 
 Điều này tạo ra một file `.so` trực tiếp trong thư mục `target/deploy` của bạn.
 

--- a/src/app/content/challenges/assembly-memo/en/challenge.mdx
+++ b/src/app/content/challenges/assembly-memo/en/challenge.mdx
@@ -1,5 +1,4 @@
 import { ArticleSection } from "../../../../components/ArticleSection/ArticleSection";
-import { Codeblock } from "../../../../components/Codeblock/Codeblock";
 
 ![Assembly Memo Challenge](/graphics/challenge-banners/assembly-memo.png)
 
@@ -15,7 +14,6 @@ If you're unfamiliar with assembly programming, follow the [introduction to Asse
 
 Our program will simply put the right memory location into the right register and then perform the `sol_log_` syscall. It will look like this:
 
-<Codeblock lang="assembly">
 ```sbpf
 .equ NUM_ACCOUNTS, 0x00
 .equ DATA_LEN, 0x08
@@ -28,19 +26,16 @@ entrypoint:
   call sol_log_
   exit
 ```
-</Codeblock>
 
 <ArticleSection name="Memory Offsets" id="memory-offsets" level="h2" />
 
 The program begins by declaring three `.equ` constants that define the memory layout of our instruction data:
 
-<Codeblock lang="assembly">
 ```sbpf
 .equ NUM_ACCOUNTS, 0x00  ; Offset for number of accounts
 .equ DATA_LEN, 0x08      ; Offset for data length
 .equ DATA, 0x10          ; Offset for actual data
 ```
-</Codeblock>
 
 These constants mark the byte-offsets relative to the entry-buffer pointer in `r1`:
 - `NUM_ACCOUNTS` (0x0000): Points to the account count in the instruction data header for validation
@@ -51,13 +46,11 @@ Unlike high-level languages that abstract memory layout, assembly requires knowi
 
 <ArticleSection name="Entrypoint and Initial Validation" id="entrypoint-and-validations" level="h2" />
 
-<Codeblock lang="assembly">
 ```sbpf
 .globl entrypoint
 entrypoint:
   ldxdw r0, [r1+NUM_ACCOUNTS]   ; Load number of accounts into r0
 ```
-</Codeblock>
 
 Every sBPF program starts at a global `.entrypoint` symbol. The Solana runtime provides account and instruction data through register `r1`.
 
@@ -69,12 +62,10 @@ This first instruction then loads the number of accounts into `r0`. Since `r0` i
 
 Next, we prepare the arguments for the `sol_log_` syscall:
 
-<Codeblock lang="assembly">
 ```sbpf
 ldxdw r2, [r1+DATA_LEN]   ; Load length of memo into r2
 add64  r1, DATA           ; Adjust r1 to point to memo bytes
 ```
-</Codeblock>
 
 These instructions set up the arguments for `sol_log_`:
 - `r2` receives the length of the memo data
@@ -82,12 +73,10 @@ These instructions set up the arguments for `sol_log_`:
 
 And after that, we call `sol_log_` and exit:
 
-<Codeblock lang="assembly">
 ```sbpf
 call 16   ; Call sol_log_ (helper ID 16)
 exit      ; Return using r0 value
 ```
-</Codeblock>
 
 <ArticleSection name="Conclusion" id="conclusion" level="h2" />
 

--- a/src/app/content/challenges/assembly-memo/vi/challenge.mdx
+++ b/src/app/content/challenges/assembly-memo/vi/challenge.mdx
@@ -1,5 +1,4 @@
 import { ArticleSection } from "../../../../components/ArticleSection/ArticleSection";
-import { Codeblock } from "../../../../components/Codeblock/Codeblock";
 
 ![Thử thách Assembly Memo](/graphics/challenge-banners/assembly-memo.png)
 
@@ -15,7 +14,6 @@ Nếu bạn không quen thuôc với ngôn ngữ lập trình assembly, bạn n�
 
 Chương trình của chúng ta sẽ đơn giản là đặt địa chỉ bộ nhớ chính xác vào các register (thanh ghi) và sau đó gọi syscall `sol_log_`:
 
-<Codeblock lang="assembly">
 ```sbpf
 .equ NUM_ACCOUNTS, 0x00
 .equ DATA_LEN, 0x08
@@ -28,19 +26,16 @@ entrypoint:
   call sol_log_
   exit
 ```
-</Codeblock>
 
 <ArticleSection name="Độ lệch của bộ nhớ" id="memory-offsets" level="h2" />
 
 Chương trình bắt đầu với việc khai báo 3 hằng số định nghĩa bố cục bộ nhớ của dữ liệu instruction của chúng ta bằng `.equ`:
 
-<Codeblock lang="assembly">
 ```sbpf
 .equ NUM_ACCOUNTS, 0x00  ; Offset for number of accounts
 .equ DATA_LEN, 0x08      ; Offset for data length
 .equ DATA, 0x10          ; Offset for actual data
 ```
-</Codeblock>
 
 Những hằng số này đánh dấu các độ lệch byte tương ứng với con trỏ buffer vào trong thanh ghi `r1`:
 - `NUM_ACCOUNTS` (0x0000): trỏ đến số lượng tài khoản trong header của dữ liệu instruction để xác thực.
@@ -51,13 +46,11 @@ Không giống như những ngôn ngữ bậc cao khác trừu tượng hóa b�
 
 <ArticleSection name="Điểm đầu vào và Xác thực ban đầu" id="entrypoint-and-validations" level="h2" />
 
-<Codeblock lang="assembly">
 ```sbpf
 .globl entrypoint
 entrypoint:
   ldxdw r0, [r1+NUM_ACCOUNTS]   ; Load number of accounts into r0
 ```
-</Codeblock>
 
 Mỗi chương trình sBPF bắt đầu bởi một ký hiệu toàn cục `.entrypoint`. Runtime Solana cung cấp các tài khoản và dữ liệu instruction thông qua thanh ghi `r1`.
 
@@ -69,12 +62,10 @@ Instruction đầu tiên này sau đó tải số lượng accounts vào thành 
 
 Tiếp theo, chúng ta chuẩn bị các đối số cho syscall `sol_log_`:
 
-<Codeblock lang="assembly">
 ```sbpf
 ldxdw r2, [r1+DATA_LEN]   ; Load length of memo into r2
 add64  r1, DATA           ; Adjust r1 to point to memo bytes
 ```
-</Codeblock>
 
 Những instruction này đặt các đối số cho syscall `sol_log_`:
 - `r2` nhận độ dài của dữ liệu memo
@@ -82,12 +73,10 @@ Những instruction này đặt các đối số cho syscall `sol_log_`:
 
 Và sau đó chúng ta gọi syscall `sol_log_` và thoát chương trình:
 
-<Codeblock lang="assembly">
 ```sbpf
 call 16   ; Call sol_log_ (helper ID 16)
 exit      ; Return using r0 value
 ```
-</Codeblock>
 
 <ArticleSection name="Kết luận" id="conclusion" level="h2" />
 

--- a/src/app/content/challenges/assembly-memo/vi/verify.mdx
+++ b/src/app/content/challenges/assembly-memo/vi/verify.mdx
@@ -11,11 +11,9 @@ Tạo một chương trình chỉ có 1 instruction. Nó phải:
 
 Bắt đầu bằng cách cài đặt các gói công cụ sBPF như được mô tả trong phần [Công cụ](/vi/courses/introduction-to-assembly/tooling) của khóa học Giới thiệu về Assembly và build chương trình của bạn bằng lệnh sau trong terminal:
 
-<Codeblock lang="terminal">
 ```bash
 sbpf build
 ```
-</Codeblock>
 
 Điều này sẽ tạo ra một file `.so` trong thư mục `target/deploy` của bạn.
 

--- a/src/app/content/challenges/assembly-slippage/en/challenge.mdx
+++ b/src/app/content/challenges/assembly-slippage/en/challenge.mdx
@@ -1,5 +1,4 @@
 import ArticleSection from "../../../../components/ArticleSection/ArticleSection";
-import { Codeblock } from "../../../../components/Codeblock/Codeblock";
 
 ![Assembly Slippage Challenge](/graphics/challenge-banners/assembly-slippage.png)
 
@@ -28,12 +27,10 @@ The program expects:
 
 sBPF programs receive account data as contiguous memory regions. These constants define byte offsets. By assuming that our program will only take in a single account, and it will be an SPL Token Account, it is possible to statically derive these offsets as:
 
-<Codeblock lang="sbpf">
 ```sbpf
 .equ TOKEN_ACCOUNT_BALANCE, 0x00a0
 .equ MINIMUM_BALANCE, 0x2918
 ```
-</Codeblock>
 
 - `TOKEN_ACCOUNT_BALANCE (0x00a0)`: points to the balance field in SPL Token account data. Token accounts follow a standard layout where the balance (8 bytes, little-endian) sits at offset 160.
 
@@ -45,14 +42,12 @@ Unlike high-level languages that abstract memory layout, assembly requires you t
 
 <ArticleSection name="Entrypoint and Initial Validation" id="entrypoint-and-validations" level="h2" />
 
-<Codeblock lang="sbpf">
 ```sbpf
 .globl entrypoint
 entrypoint:
     ldxdw r3, [r1+MINIMUM_BALANCE]      // Get amount from IX data
     ldxdw r4, [r1+TOKEN_ACCOUNT_BALANCE] // Get balance from token account
 ```
-</Codeblock>
 
 Every sBPF program starts at a global `.entrypoint` symbol. The Solana runtime provides account and instruction data through register `r1`.
 
@@ -64,11 +59,9 @@ Both operations are zero-copy: we're reading directly from the account data with
 
 <ArticleSection name="Conditional Logic and Branching" id="conditional-logic-and-branching" level="h2" />
 
-<Codeblock lang="sbpf">
 ```sbpf
 jge r3, r4, end         // Skip to exit if balance is valid
 ```
-</Codeblock>
 
 
 The `jge` (jump if greater or equal) instruction compares `r3` (required amount) against `r4` (available balance). If `r3 >= r4`, we jump to the `end` label; just like an early return.
@@ -77,14 +70,12 @@ If the condition fails, execution continues to the error handling path. This bra
 
 <ArticleSection name="Error Handling and Logging" id="error-handling-and-logging" level="h2" />
 
-<Codeblock lang="sbpf">
 ```sbpf
 lddw r1, e              // Load error message address
 lddw r2, 17             // Load length of error message  
 call sol_log_           // Log out error message
 lddw r0, 1              // Return error code 1
 ```
-</Codeblock>
 
 When validation fails, we log a human-readable error before terminating:
 - `lddw` loads immediate values, in this case the address of our error string, that lives in the `.rodata` section, and its length (17 bytes for "Slippage exceeded").
@@ -93,12 +84,10 @@ When validation fails, we log a human-readable error before terminating:
 
 <ArticleSection name="Program Termination" id="program-termination" level="h2" />
 
-<Codeblock lang="sbpf">
 ```sbpf
 end:
     exit
 ```
-</Codeblock>
 
 The `exit` instruction terminates program execution and returns control to the Solana runtime. The value in `r0` becomes the program's exit code (0 for success, non-zero for errors).
 
@@ -106,12 +95,10 @@ Unlike high-level languages with automatic cleanup, assembly programs must expli
 
 ## Read-only Data
 
-<Codeblock lang="sbpf">
 ```sbpf
 .rodata
     e: .ascii "Slippage exceeded"
 ```
-</Codeblock>
 
 The `.rodata` (read-only data) section contains our error message string.
 

--- a/src/app/content/challenges/assembly-slippage/vi/challenge.mdx
+++ b/src/app/content/challenges/assembly-slippage/vi/challenge.mdx
@@ -1,5 +1,4 @@
 import ArticleSection from "../../../../components/ArticleSection/ArticleSection";
-import { Codeblock } from "../../../../components/Codeblock/Codeblock";
 
 ![Thử thách Assembly Slippage](/graphics/challenge-banners/assembly-slippage.png)
 
@@ -32,12 +31,10 @@ Chương trình của chúng ta sẽ cần:
 
 Chương trình sBPF nhận dữ liệu tài khoản dưới dạng các vùng nhớ liên tục. Các hằng số này xác định các độ lệch byte. Bằng cách giả định rằng chương trình của chúng ta chỉ nhận một tài khoản, và đó là một tài khoản token SPL, chúng ta có thể gán tĩnh các độ lệch này như sau:
 
-<Codeblock lang="sbpf">
 ```sbpf
 .equ TOKEN_ACCOUNT_BALANCE, 0x00a0
 .equ MINIMUM_BALANCE, 0x2918
 ```
-</Codeblock>
 
 - `TOKEN_ACCOUNT_BALANCE (0x00a0)`: trỏ đến trường số dư trong dữ liệu của SPL Token account. Các token account tuân theo một bố cụng chuẩn mà số dư (8 bytes, little-endian) nằm ở offset 160.
 
@@ -49,14 +46,12 @@ Không giống như những ngôn ngữ bậc cao khác trừu tượng hóa b�
 
 <ArticleSection name="Điểm đầu vào và Xác thực ban đầu" id="entrypoint-and-validations" level="h2" />
 
-<Codeblock lang="sbpf">
 ```sbpf
 .globl entrypoint
 entrypoint:
     ldxdw r3, [r1+MINIMUM_BALANCE]      // Get amount from IX data
     ldxdw r4, [r1+TOKEN_ACCOUNT_BALANCE] // Get balance from token account
 ```
-</Codeblock>
 
 Mỗi chương trình sBPF bắt đầu bởi một ký hiệu toàn cục `.entrypoint`. Runtime Solana cung cấp các tài khoản và dữ liệu instruction thông qua thanh ghi `r1`.
 
@@ -68,11 +63,9 @@ Cả 2 hành động đều là zero-copy: chúng ta đang đọc trực tiếp 
 
 <ArticleSection name="Logic điều kiện và phân nhánh" id="conditional-logic-and-branching" level="h2" />
 
-<Codeblock lang="sbpf">
 ```sbpf
 jge r3, r4, end         // Skip to exit if balance is valid
 ```
-</Codeblock>
 
 
 Instruction `jge` (jump if greater or equal) (thoát ra nếu lớn hơn hoặc bằng)  compares `r3` (số lượng được yêu cầu) với `r4` (số dư trong tài khoản token). nếu `r3 >= r4`, chúng ta nhảy đến nhãn `end`; giống như một lệnh thoát sớm.
@@ -81,14 +74,12 @@ Nếu điều kiện không thỉa, thực thi tiếp tục đến đường d�
 
 <ArticleSection name="Xử lý lỗi và ghi log" id="error-handling-and-logging" level="h2" />
 
-<Codeblock lang="sbpf">
 ```sbpf
 lddw r1, e              // Load error message address
 lddw r2, 17             // Load length of error message  
 call sol_log_           // Log out error message
 lddw r0, 1              // Return error code 1
 ```
-</Codeblock>
 
 Khi kiểm tra thất bại, chúng ta ghi log một thông báo lỗi có thể đọc được trước khi kết thúc chương trình:
 - `lddw` tải vào các giá trị ngay lập tức, trong trường hợp này là địa chỉ của chuỗi thông báo lỗi của chúng ta, nằm trong phần `.rodata`, và độ dài của chuỗi thông báo lỗi (17 byte cho "Slippage exceeded").
@@ -97,12 +88,10 @@ Khi kiểm tra thất bại, chúng ta ghi log một thông báo lỗi có thể
 
 <ArticleSection name="Kết thúc chương trình" id="program-termination" level="h2" />
 
-<Codeblock lang="sbpf">
 ```sbpf
 end:
     exit
 ```
-</Codeblock>
 
 Instruction `exit` ngắt thực thi chương trình và trả quyền kiểm soát cho runtime Solana. Giá trị trong `r0` trở thành mã thoát của chương trình (0 nếu thành công, giá trị khác 0 nếu lỗi).
 
@@ -110,12 +99,10 @@ Không giống như những ngôn ngữ bậc cao khác có xử lý dọn dẹp
 
 ## Dữ liệu chỉ đọc
 
-<Codeblock lang="sbpf">
 ```sbpf
 .rodata
     e: .ascii "Slippage exceeded"
 ```
-</Codeblock>
 
 Phần `.rodata` (read-only data) (dữ liệu chỉ đọc) bao gồm chuỗi thông báo lỗi của chúng ta.
 

--- a/src/app/content/challenges/assembly-timeout/en/challenge.mdx
+++ b/src/app/content/challenges/assembly-timeout/en/challenge.mdx
@@ -1,5 +1,4 @@
 import ArticleSection from "../../../../components/ArticleSection/ArticleSection";
-import { Codeblock } from "../../../../components/Codeblock/Codeblock";
 
 # Assembly Timeout
 
@@ -34,13 +33,11 @@ Since our program accepts zero accounts, we can calculate where `MAX_SLOT_HEIGHT
 
 These constants define our memory layout:   
 
-<Codeblock lang="sbpf">
 ```sbpf
 .equ NUM_ACCOUNTS, 0x0000
 .equ MAX_SLOT_HEIGHT, 0x0010
 .equ CURRENT_SLOT_HEIGHT, -0x0028
 ```
-</Codeblock>
 
 - `NUM_ACCOUNTS` (0x0000): Points to the account count in the instruction data header for validation
 - `MAX_SLOT_HEIGHT` (0x0010): Locates the 8-byte deadline slot height within the instruction data payload
@@ -50,14 +47,12 @@ Unlike high-level languages that abstract memory layout, assembly requires knowi
 
 <ArticleSection name="Entrypoint and Initial Validation" id="entrypoint-and-validations" level="h2" />
 
-<Codeblock lang="sbpf">
 ```sbpf
 .globl entrypoint
 entrypoint:
   ldxdw r0, [r1+NUM_ACCOUNTS]       // Veto if any accounts are included
   ldxdw r2, [r1+MAX_SLOT_HEIGHT]    // Store target slot height
 ```
-</Codeblock>
 
 Every sBPF program starts at a global `.entrypoint` symbol. The Solana runtime provides account and instruction data through register `r1`.
 
@@ -69,14 +64,12 @@ Both operations are zero-copy: we're reading directly from the account data with
 
 <ArticleSection name="The Clock Sysvar" id="the-clock-sysvar" level="h2" />
 
-<Codeblock lang="sbpf">
 ```sbpf
 mov64 r1, r10
 add64 r1, CURRENT_SLOT_HEIGHT
 call sol_get_clock_sysvar
 ldxdw r1, [r1+0x0000]
 ```
-</Codeblock>
 
 The `sol_get_clock_sysvar` syscall writes current `Clock` data to `r1`. 
 
@@ -90,12 +83,10 @@ After calling the `sol_get_clock_sysvar` function, `r1` contains the memory addr
 
 <ArticleSection name="Temporal Comparison Logic" id="temporal-comparison-logic" level="h2" />
 
-<Codeblock lang="sbpf">
 ```sbpf
 jle r1, r2, end    // If current slot <= max slot, success
 lddw r0, 1         // Otherwise, set error code
 ```
-</Codeblock>
 
 The core timeout logic uses a single conditional jump:
 - Temporal validation: `jle` (jump if less or equal) compares current slot (`r1`) against our deadline (`r2`). If we're within the time window, jump to `exit`

--- a/src/app/content/challenges/assembly-timeout/vi/challenge.mdx
+++ b/src/app/content/challenges/assembly-timeout/vi/challenge.mdx
@@ -1,5 +1,4 @@
 import ArticleSection from "../../../../components/ArticleSection/ArticleSection";
-import { Codeblock } from "../../../../components/Codeblock/Codeblock";
 
 # Assembly Timeout
 
@@ -35,13 +34,11 @@ Vì chương trình của chúng ta không nhận bất kỳ tài khoản nào, 
 
 Các hằng số định nghĩa bố cục bộ nhớ của chúng ta như sau: 
 
-<Codeblock lang="sbpf">
 ```sbpf
 .equ NUM_ACCOUNTS, 0x0000
 .equ MAX_SLOT_HEIGHT, 0x0010
 .equ CURRENT_SLOT_HEIGHT, -0x0028
 ```
-</Codeblock>
 
 - `NUM_ACCOUNTS` (0x0000): Trỏ đến số lượng tài khoản trong header của dữ liệu instruction để xác thực.
 - `MAX_SLOT_HEIGHT` (0x0010): Xác định vị trí của 8-byte slot-height tối đa trong dữ liệu của instruction.
@@ -51,14 +48,12 @@ Không giống như những ngôn ngữ bậc cao khác trừu tượng hóa b�
 
 <ArticleSection name="Điểm đầu vào và Xác thực ban đầu" id="entrypoint-and-validations" level="h2" />
 
-<Codeblock lang="sbpf">
 ```sbpf
 .globl entrypoint
 entrypoint:
   ldxdw r0, [r1+NUM_ACCOUNTS]       // Veto if any accounts are included
   ldxdw r2, [r1+MAX_SLOT_HEIGHT]    // Store target slot height
 ```
-</Codeblock>
 
 Mỗi chương trình sBPF bắt đầu bởi một ký hiệu toàn cục `.entrypoint`. Runtime Solana cung cấp các tài khoản và dữ liệu instruction thông qua thanh ghi `r1`.
 
@@ -70,14 +65,12 @@ Cả 2 hành động đều là zero-copy: chúng ta đang đọc trực tiếp 
 
 <ArticleSection name="Clock Sysvar" id="the-clock-sysvar" level="h2" />
 
-<Codeblock lang="sbpf">
 ```sbpf
 mov64 r1, r10
 add64 r1, CURRENT_SLOT_HEIGHT
 call sol_get_clock_sysvar
 ldxdw r1, [r1+0x0000]
 ```
-</Codeblock>
 
 Việc gọi `sol_get_clock_sysvar` syscall sẽ ghi dữ liệu `Clock` hiện tại vào `r1`.
 
@@ -91,12 +84,10 @@ Sau khi gọi hàm `sol_get_clock_sysvar`, thanh ghi `r1` chứa địa chỉ b�
 
 <ArticleSection name="Logic so sánh thời gian" id="temporal-comparison-logic" level="h2" />
 
-<Codeblock lang="sbpf">
 ```sbpf
 jle r1, r2, end    // If current slot <= max slot, success
 lddw r0, 1         // Otherwise, set error code
 ```
-</Codeblock>
 
 Logic chính của chúng ta là một lệnh nhảy:
 - Temporal validation: lệnh `jle` (jump if less or equal) (nhảy nếu nhỏ hơn hoặc bằng) so sánh slot hiện tại ở thanh ghi (`r1`) với deadline của chúng ta ở thanh ghi (`r2`). Nếu chúng ta còn trong cửa sổ thời gian, chúng ta nhảy đến nhãn `end`.

--- a/src/app/content/challenges/assembly-timeout/vi/verify.mdx
+++ b/src/app/content/challenges/assembly-timeout/vi/verify.mdx
@@ -16,11 +16,9 @@ Tạo một chương trình chỉ có 1 instruction. Nó phải:
 
 Hãy bắt đầu bằng cách cài đặt các gói công cụ sBPF như được mô tả trong phần [Công cụ](/vi/courses/introduction-to-assembly/tooling) của khóa học Giới thiệu về Assembly và build chương trình của bạn bằng lệnh sau trong terminal:
 
-<Codeblock lang="terminal">
 ```bash
 sbpf build
 ```
-</Codeblock>
 
 Điều này sẽ tạo ra một file `.so` trong thư mục `target/deploy` của bạn.
 

--- a/src/app/content/challenges/pinocchio-amm/en/challenge.mdx
+++ b/src/app/content/challenges/pinocchio-amm/en/challenge.mdx
@@ -1,5 +1,4 @@
 import ArticleSection from "../../../../components/ArticleSection/ArticleSection";
-import { Codeblock } from "../../../../components/Codeblock/Codeblock";
 
 # The Amm
 
@@ -23,31 +22,25 @@ In this challenge, you'll implement a simple AMM with four core instructions:
 
 Let's start by creating a fresh Rust environment:
 
-<Codeblock lang="terminal">
 ```bash
 # create workspace
 cargo new blueshift_native_amm --lib --edition 2021
 cd blueshift_native_amm
 ```
-</Codeblock>
 
 Add `pinocchio`, `pinocchio-system`, `pinocchio-token`, `pinocchio-associated-token-account` and the `constant-product-curve` created by [Dean](https://x.com/deanmlittle) to handle all calculation for our Amm:
 
-<Codeblock lang="terminal">
 ```bash
 cargo add pinocchio pinocchio-system pinocchio-token pinocchio-associated-token-account
 cargo add --git="https://github.com/deanmlittle/constant-product-curve" constant-product-curve
 ```
-</Codeblock>
 
 Declare the crate types in `Cargo.toml` to generate deployment artifacts in `target/deploy`:
 
-<Codeblock lang="toml">
 ```toml
 [lib]
 crate-type = ["lib", "cdylib"]
 ```
-</Codeblock>
 
 You're now ready to write your amm program.
 
@@ -104,7 +97,6 @@ src
 
 The entrypoint, that lives in the `lib.rs` looks always the same:
 
-<Codeblock lang="rust">
 ```rust
 use pinocchio::{
     account_info::AccountInfo, entrypoint, program_error::ProgramError, pubkey::Pubkey,
@@ -140,7 +132,6 @@ fn process_instruction(
     }
 }
 ```
-</Codeblock>
 
 <ArticleSection name="State" id="state" level="h2" />
 
@@ -150,7 +141,6 @@ Let's break this down into three parts: the struct definition, reading helpers, 
 
 First, let's look at the struct definition:
 
-<Codeblock lang="rust">
 ```rust
 use core::mem::size_of;
 use pinocchio::{account_info::AccountInfo, program_error::ProgramError, pubkey::Pubkey};
@@ -180,7 +170,6 @@ impl Config {
     //...
 }
 ```
-</Codeblock>
 
 The `#[repr(C)]` attribute ensures our struct has a predictable, C-compatible memory layout that remains consistent across different platforms and Rust compiler versions. This is crucial for on-chain programs where data must be serialized and deserialized reliably.
 
@@ -201,7 +190,6 @@ The `AmmState` enum defines the possible states for the AMM, making it easy to m
 
 The reading helpers provide safe, efficient access to the `Config` data with proper validation and borrowing:
 
-<Codeblock lang="rust">
 ```rust
 impl Config {
     //...
@@ -278,7 +266,6 @@ impl Config {
     pub fn config_bump(&self) -> [u8; 1] { self.config_bump }
 }
 ```
-</Codeblock>
 
 Key features of the reading helpers:
 - Safe Borrowing: The `load` method returns a `Ref<Self>` that safely manages borrowing from the account data, preventing data races and ensuring memory safety.
@@ -290,7 +277,6 @@ Key features of the reading helpers:
 
 The writing helpers provide safe, validated methods for modifying the `Config` data:
 
-<Codeblock lang="rust">
 ```rust
 impl Config {
     //...
@@ -358,7 +344,6 @@ impl Config {
     }
 }
 ```
-</Codeblock>
 
 Key features of the writing helpers:
 - Mutable Borrowing: The `load_mut` method returns a `RefMut<Self>` that safely manages mutable borrowing from the account data.

--- a/src/app/content/challenges/pinocchio-amm/en/pages/deposit.mdx
+++ b/src/app/content/challenges/pinocchio-amm/en/pages/deposit.mdx
@@ -22,7 +22,6 @@ Below are the accounts required for this context:
 
 Here, again, I’ll leave the implementation to you:
 
-<Codeblock lang="rust">
 ```rust
 pub struct DepositAccounts<'a> {
     pub user: &'a AccountInfo,
@@ -44,7 +43,6 @@ impl<'a> TryFrom<&'a [AccountInfo]> for DepositAccounts<'a> {
   }
 }
 ```
-</Codeblock>
 
 <ArticleSection name="Instruction Data" id="instruction-data" level="h2" />
 
@@ -56,7 +54,6 @@ Here's the instruction data we need to pass in:
 
 We're going to handle the implementation for the `DepositInstructionData` same as initialization. So I’ll leave the implementation to you:
 
-<Codeblock lang="rust">
 ```rust
 pub struct DepositInstructionData {
     pub amount: u64,
@@ -73,7 +70,6 @@ impl<'a> TryFrom<&'a [u8]> for DepositInstructionData {
     }
 }
 ```
-</Codeblock>
 
 > Make sure that any of the amount, like `amount`, `max_y` and `max_x` are greater than zero and that the order has not expired yet using the `Clock` sysvar.
 
@@ -85,7 +81,6 @@ We then need to:
 - Load the `Config` account to grab all the data inside of it. We can do so using the `Config::load()` helper.
 - Verify that the `AmmState` is valid (so if it's equal to `AmmState::Initialized`)
 - Check the derivation of `vault_x` and `vault_y` to be Associated Token Accounts like this:
-<Codeblock lang="rust">
 ```rust
 // Check if the vault_x is valid
 let (vault_x, _) = find_program_address(
@@ -101,9 +96,7 @@ if vault_x.ne(self.accounts.vault_x.key()) {
     return Err(ProgramError::InvalidAccountData);
 }
 ```
-</Codeblock>
 - Deserialize all the token accounts involved and use the data inside of them to calculate the amount to deposits using the `constant-product-curve` crate and checking for slippage like this:
-<Codeblock lang="rust">
 ```rust
 // Deserialize the token accounts
 let mint_lp = unsafe { Mint::from_account_info_unchecked(self.accounts.mint_lp)? };
@@ -132,7 +125,6 @@ if !(x <= self.instruction_data.max_x && y <= self.instruction_data.max_y) {
     return Err(ProgramError::InvalidArgument);
 }
 ```
-</Codeblock>
 
 > If it's the first deposit, we can skip the calculation of LP tokens and deposits and just go with the value that the user suggest
 
@@ -140,7 +132,6 @@ if !(x <= self.instruction_data.max_x && y <= self.instruction_data.max_y) {
 
 You should be proficient enough to this on your own, so I’ll leave the implementation to you:
 
-<Codeblock lang="rust">
 ```rust
 pub struct Deposit<'a> {
     pub accounts: DepositAccounts<'a>,
@@ -172,4 +163,3 @@ impl<'a> Deposit<'a> {
     }
 }
 ```
-</Codeblock>

--- a/src/app/content/challenges/pinocchio-amm/en/pages/initialize.mdx
+++ b/src/app/content/challenges/pinocchio-amm/en/pages/initialize.mdx
@@ -18,7 +18,6 @@ Below are the accounts required for this context:
 
 Since there aren’t many changes from the usual struct we create, I’ll leave the implementation to you:
 
-<Codeblock lang="rust">
 ```rust
 pub struct InitializeAccounts<'a> {
     pub initializer: &'a AccountInfo,
@@ -34,7 +33,6 @@ impl<'a> TryFrom<&'a [AccountInfo]> for InitializeAccounts<'a> {
   }
 }
 ```
-</Codeblock>
 
 > You’ll need to pass in all the accounts discussed above, but not all of them need to be included in the `InitializeAccounts` struct, since you may not need to reference every account directly in the implementation.
 
@@ -53,7 +51,6 @@ Here's the instruction data we need to pass in:
 
 In this implementation, we’re handling instruction data parsing in a more flexible and low-level way than usual. For this reason we'll explain why we're making the following decisions:
 
-<Codeblock lang="rust">
 ```rust
 #[repr(C, packed)]
 pub struct InitializeInstructionData {
@@ -96,7 +93,6 @@ impl TryFrom<&[u8]> for InitializeInstructionData {
     }
 }
 ```
-</Codeblock>
 
 The authority field in `InitializeInstructionData` is optional and can be omitted to create an immutable pool.
 
@@ -108,7 +104,6 @@ We begin by deserializing both the `instruction_data` and the `accounts`.
 
 We then need to:
 - Create the `Config` account using the `CreateAccount` instruction from the system program and the following seeds:
-<Codeblock lang="rust">
 ```rust
 let seed_binding = self.instruction_data.seed.to_le_bytes();
 let config_seeds = [
@@ -119,10 +114,8 @@ let config_seeds = [
     Seed::from(&self.instruction_data.config_bump),
 ];
 ```
-</Codeblock>
 - Populate the `Config` account loading it using the `Config::load_mut_unchecked()` helper and then populating it with all the data needed using the `config.set_inner()` helper.
 - Create the `Mint` account for the lp using the `CreateAccount` and `InitializeMint2` instruction and the following seeds:
-<Codeblock lang="rust">
 ```rust
 let mint_lp_seeds = [
     Seed::from(b"mint_lp"),
@@ -130,13 +123,11 @@ let mint_lp_seeds = [
     Seed::from(&self.instruction_data.lp_bump),
 ];
 ```
-</Codeblock>
 
 > The `mint_authority` of the `mint_lp` is the `config` account
 
 You should be proficient enough to this on your own, so I’ll leave the implementation to you:
 
-<Codeblock lang="rust">
 ```rust
 pub struct Initialize<'a> {
     pub accounts: InitializeAccounts<'a>,
@@ -167,7 +158,6 @@ impl<'a> Initialize<'a> {
     }
 }
 ```
-</Codeblock>
 
 <ArticleSection name="Security" id="security" level="h2" />
 

--- a/src/app/content/challenges/pinocchio-amm/en/pages/swap.mdx
+++ b/src/app/content/challenges/pinocchio-amm/en/pages/swap.mdx
@@ -19,7 +19,6 @@ Below are the accounts required for this context:
 
 Here, again, I’ll leave the implementation to you:
 
-<Codeblock lang="rust">
 ```rust
 pub struct SwapAccounts<'a> {
     pub user: &'a AccountInfo,
@@ -39,7 +38,6 @@ impl<'a> TryFrom<&'a [AccountInfo]> for SwapAccounts<'a> {
     }
 }
 ```
-</Codeblock>
 
 <ArticleSection name="Instruction Data" id="instruction-data" level="h2" />
 
@@ -51,7 +49,6 @@ Here's the instruction data we need to pass in:
 
 We're going to handle the implementation for the `SwapInstructionData` same as initialization. So I’ll leave the implementation to you:
 
-<Codeblock lang="rust">
 ```rust
 pub struct SwapInstructionData {
     pub is_x: bool,
@@ -68,7 +65,6 @@ impl<'a> TryFrom<&'a [u8]> for SwapInstructionData {
     }
 }
 ```
-</Codeblock>
 
 > Make sure that any of the amount, like `amount` and `min` are greater than zero and that the order has not expired yet using the `Clock` sysvar.
 
@@ -81,7 +77,6 @@ We then need to:
 - Verify that the `AmmState` is valid (so if it's equal to `AmmState::Initialized`).
 - Check the derivation of `vault_x` and `vault_y` to be Associated Token Accounts.
 - Deserialize all the token accounts involved and use the data inside of them to calculate the amount to swap using the `constant-product-curve` crate and checking for slippage like this:
-<Codeblock lang="rust">
 ```rust
 // Deserialize the token accounts
 let vault_x = unsafe { TokenAccount::from_account_info_unchecked(self.accounts.vault_x)? };
@@ -111,11 +106,9 @@ if swap_result.deposit == 0 || swap_result.withdraw == 0 {
     return Err(ProgramError::InvalidArgument);
 }
 ```
-</Codeblock>
 
 - Create the transfer logic checking the `is_x` value and transfer the `from` amounts to the vaults and the `to` amounts to the user token accounts like this:
 
-<Codeblock lang="rust">
 ```rust
 if self.instruction_data.is_x {
     Transfer {
@@ -140,11 +133,9 @@ if self.instruction_data.is_x {
     .invoke_signed(&signer_seeds)?;
 }
 ```
-</Codeblock>
 
 You should be proficient enough to do this on your own, so I’ll leave the implementation to you:
 
-<Codeblock lang="rust">
 ```rust
 pub struct Swap<'a> {
     pub accounts: SwapAccounts<'a>,
@@ -175,4 +166,3 @@ impl<'a> Swap<'a> {
     }
 }
 ```
-</Codeblock>

--- a/src/app/content/challenges/pinocchio-amm/en/pages/withdraw.mdx
+++ b/src/app/content/challenges/pinocchio-amm/en/pages/withdraw.mdx
@@ -22,7 +22,6 @@ Below are the accounts required for this context:
 
 Here, again, I’ll leave the implementation to you:
 
-<Codeblock lang="rust">
 ```rust
 pub struct WithdrawAccounts<'a> {
     pub user: &'a AccountInfo,
@@ -44,7 +43,6 @@ impl<'a> TryFrom<&'a [AccountInfo]> for WithdrawAccounts<'a> {
     }
 }
 ```
-</Codeblock>
 
 <ArticleSection name="Instruction Data" id="instruction-data" level="h2" />
 
@@ -56,7 +54,6 @@ Here's the instruction data we need to pass in:
 
 We're going to handle the implementation for the `WithdrawInstructionData` same as initialization. So I’ll leave the implementation to you:
 
-<Codeblock lang="rust">
 ```rust
 pub struct WithdrawInstructionData {
     pub amount: u64,
@@ -73,7 +70,6 @@ impl<'a> TryFrom<&'a [u8]> for WithdrawInstructionData {
     }
 }
 ```
-</Codeblock>
 
 > Make sure that any of the amount, like `amount`, `min_y` and `min_x` are greater than zero and that the order has not expired yet using the `Clock` sysvar.
 
@@ -86,7 +82,6 @@ We then need to:
 - Verify that the `AmmState` is valid (so if it's not equal to `AmmState::Disabled`).
 - Check the derivation of `vault_x` and `vault_y` to be Associated Token Accounts.
 - Deserialize all the token accounts involved and use the data inside of them to calculate the amount to withdraw using the `constant-product-curve` crate and checking for slippage like this:
-<Codeblock lang="rust">
 ```rust
 let mint_lp = unsafe { Mint::from_account_info_unchecked(self.accounts.mint_lp)? };
 let vault_x = unsafe { TokenAccount::from_account_info_unchecked(self.accounts.vault_x)? };
@@ -113,14 +108,12 @@ if !(x >= self.instruction_data.min_x && y >= self.instruction_data.min_y) {
     return Err(ProgramError::InvalidArgument);
 }
 ```
-</Codeblock>
 - Transfer the amounts from the vaults to the token accounts of the user and burn the appropriate amount of LP tokens from the user token account
 
 > The `authority` of `vault_x` and `vault_y` is the `config` account
 
 You should be proficient enough to do this on your own, so I’ll leave the implementation to you:
 
-<Codeblock lang="rust">
 ```rust
 pub struct Withdraw<'a> {
     pub accounts: WithdrawAccounts<'a>,
@@ -152,4 +145,3 @@ impl<'a> Withdraw<'a> {
     }
 }
 ```
-</Codeblock>

--- a/src/app/content/challenges/pinocchio-amm/fr/challenge.mdx
+++ b/src/app/content/challenges/pinocchio-amm/fr/challenge.mdx
@@ -20,31 +20,25 @@ Dans ce challenge, vous allez implémenter un AMM simple à l'aide de quatre ins
 
 Commençons par créer un nouvel environnement Rust :
 
-<Codeblock lang="terminal">
 ```bash
 # create workspace
 cargo new blueshift_native_amm --lib --edition 2021
 cd blueshift_native_amm
 ```
-</Codeblock>
 
 Ajoutez `pinocchio`, `pinocchio-system`, `pinocchio-token`, `pinocchio-associated-token-account` et `constant-product-curve` créé par [Dean](https://x.com/deanmlittle) pour gérer tous les calculs pour notre Amm :
 
-<Codeblock lang="terminal">
 ```bash
 cargo add pinocchio pinocchio-system pinocchio-token pinocchio-associated-token-account
 cargo add --git="https://github.com/deanmlittle/constant-product-curve" constant-product-curve
 ```
-</Codeblock>
 
 Déclarez les types de crate dans `Cargo.toml` pour générer les artefacts de déploiement dans `target/deploy` :
 
-<Codeblock lang="toml">
 ```toml
 [lib]
 crate-type = ["lib", "cdylib"]
 ```
-</Codeblock>
 
 Vous êtes maintenant prêt à écrire votre programme amm.
 
@@ -101,7 +95,6 @@ src
 
 Le point d'entrée, qui se trouve dans le fichier `lib.rs`, est toujours identique :
 
-<Codeblock lang="rust">
 ```rust
 use pinocchio::{
     account_info::AccountInfo, entrypoint, program_error::ProgramError, pubkey::Pubkey,
@@ -137,7 +130,6 @@ fn process_instruction(
     }
 }
 ```
-</Codeblock>
 
 <ArticleSection name="État (State)" id="state" level="h2" />
 
@@ -147,7 +139,6 @@ Décomposons cela en trois parties : la définition de la structure, les fonctio
 
 Commençons par examiner la définition de la structure :
 
-<Codeblock lang="rust">
 ```rust
 use core::mem::size_of;
 use pinocchio::{account_info::AccountInfo, program_error::ProgramError, pubkey::Pubkey};
@@ -177,7 +168,6 @@ impl Config {
     //...
 }
 ```
-</Codeblock>
 
 L'attribut `#[repr(C)]` garantit que notre structure dispose d'une disposition mémoire prédictible et compatible avec le langage C, qui reste cohérente sur différentes plateformes et versions du compilateur Rust. Ceci est crucial pour les programmes on-chain où les données doivent être sérialisées et désérialisées de manière fiable.
 
@@ -198,7 +188,6 @@ L'enum `AmmState` définit les états possibles pour l'AMM, ce qui facilite la g
 
 Les fonctions d'aide pour la lecture fournit un accès sûr et efficace aux données de `Config` avec une validation et des emprunts appropriés :
 
-<Codeblock lang="rust">
 ```rust
 impl Config {
     //...
@@ -275,7 +264,6 @@ impl Config {
     pub fn config_bump(&self) -> [u8; 1] { self.config_bump }
 }
 ```
-</Codeblock>
 
 Principales caractéristiques des fonctions d'aide pour la lecture :
 - Emprunt Sûr : La méthode `load` renvoie un `Ref<Self>` qui gère en toute sécurité l'emprunt des données du compte, empêchant ainsi les conflits d'accès aux données et garantissant la sécurité de la mémoire.
@@ -287,7 +275,6 @@ Principales caractéristiques des fonctions d'aide pour la lecture :
 
 Les fonctions d'aide pour l'écriture fournit des méthodes sûres et validées pour modifier les données de `Config` :
 
-<Codeblock lang="rust">
 ```rust
 impl Config {
     //...
@@ -355,7 +342,6 @@ impl Config {
     }
 }
 ```
-</Codeblock>
 
 Principales caractéristiques des fonctions d'aide pour l'écriture :
 - Emprunt Mutable: La méthode `load_mut` renvoie un `RefMut<Self>` qui gère en toute sécurité l'emprunt mutable à partir des données du compte.

--- a/src/app/content/challenges/pinocchio-amm/fr/pages/deposit.mdx
+++ b/src/app/content/challenges/pinocchio-amm/fr/pages/deposit.mdx
@@ -22,7 +22,6 @@ Voici les comptes nécessaires pour ce contexte :
 
 Ici encore, je vous laisse le soin de l'implémenter :
 
-<Codeblock lang="rust">
 ```rust
 pub struct DepositAccounts<'a> {
     pub user: &'a AccountInfo,
@@ -44,7 +43,6 @@ impl<'a> TryFrom<&'a [AccountInfo]> for DepositAccounts<'a> {
   }
 }
 ```
-</Codeblock>
 
 <ArticleSection name="Données d'Instruction" id="instruction-data" level="h2" />
 
@@ -56,7 +54,6 @@ Voici les données d'instruction que nous devons transmettre :
 
 Nous allons gérer l'implémentation de `DepositInstructionData` de la même manière que l'initialisation. Je vous laisse donc le soin de l'implémenter :
 
-<Codeblock lang="rust">
 ```rust
 pub struct DepositInstructionData {
     pub amount: u64,
@@ -73,7 +70,6 @@ impl<'a> TryFrom<&'a [u8]> for DepositInstructionData {
     }
 }
 ```
-</Codeblock>
 
 > Assurez-vous que tous les montants, telles que `amount`, `max_y` et `max_x`, sont supérieurs à zéro et que l'ordre n'a pas encore expiré à l'aide de la sysvar `Clock`.
 
@@ -86,7 +82,6 @@ Nous devons ensuite :
 - Vérifiez que `AmmState` est valide (donc si c'est égal à `AmmState::Initialized`)
 - Vérifiez que la dérivation de `vault_x` et `vault_y` correspond bien à des Comptes de Jetons Associés, comme ceci :
 
-<Codeblock lang="rust">
 ```rust
 // Check if the vault_x is valid
 let (vault_x, _) = find_program_address(
@@ -102,11 +97,9 @@ if vault_x.ne(self.accounts.vault_x.key()) {
     return Err(ProgramError::InvalidAccountData);
 }
 ```
-</Codeblock>
 
 - Désérialisez tous les comptes de jetons impliqués et utilisez les données qu'ils contiennent pour calculer le montant des dépôts à l'aide du crate `constant-product-curve` et vérifiez le slippage comme ceci :
 
-<Codeblock lang="rust">
 ```rust
 // Deserialize the token accounts
 let mint_lp = unsafe { Mint::from_account_info_unchecked(self.accounts.mint_lp)? };
@@ -135,7 +128,6 @@ if !(x <= self.instruction_data.max_x && y <= self.instruction_data.max_y) {
     return Err(ProgramError::InvalidArgument);
 }
 ```
-</Codeblock>
 
 > S'il s'agit du premier dépôt, nous pouvons ignorer le calcul des jetons LP et des dépôts et simplement utiliser la valeur suggérée par l'utilisateur
 
@@ -143,7 +135,6 @@ if !(x <= self.instruction_data.max_x && y <= self.instruction_data.max_y) {
 
 Vous devriez être suffisamment compétent pour le faire vous-même, je vous laisse donc le soin de l'implémenter :
 
-<Codeblock lang="rust">
 ```rust
 pub struct Deposit<'a> {
     pub accounts: DepositAccounts<'a>,
@@ -175,4 +166,3 @@ impl<'a> Deposit<'a> {
     }
 }
 ```
-</Codeblock>

--- a/src/app/content/challenges/pinocchio-amm/fr/pages/initialize.mdx
+++ b/src/app/content/challenges/pinocchio-amm/fr/pages/initialize.mdx
@@ -17,7 +17,6 @@ Voici les comptes nécessaires pour ce contexte :
 > Avec l'expérience, vous remarquerez que bon nombre de ces vérifications peuvent être omises en vous appuyant plutôt sur les contraintes imposées par les CPI eux-mêmes. Par exemple, pour cette structure de compte, aucun contrôle explicite n'est nécessaire. En effet, si les contraintes ne sont pas respectées, le programme échouera par défaut. Je soulignerai ces nuances au fur et à mesure que nous avancerons dans la logique.
 Comme il n'y a pas beaucoup de changements par rapport à la structure habituelle que nous créons, je vous laisse le soin de l'implémentation :
 
-<Codeblock lang="rust">
 ```rust
 pub struct InitializeAccounts<'a> {
     pub initializer: &'a AccountInfo,
@@ -33,7 +32,6 @@ impl<'a> TryFrom<&'a [AccountInfo]> for InitializeAccounts<'a> {
   }
 }
 ```
-</Codeblock>
 
 > Vous devrez passer tous les comptes mentionnés ci-dessus mais tous ne doivent pas nécessairement être inclus dans la structure `InitializeAccounts` car vous n'aurez peut-être pas besoin de référencer directement chaque compte dans l'implémentation
 
@@ -51,7 +49,6 @@ Voici les données d'instruction que nous devons transmettre :
 > Comme vous pouvez le constater, plusieurs de ces champs pourraient être dérivés différemment. Par exemple, nous pourrions obtenir le `mint_x` en passant le compte de `Mint` et en le lisant directement ou générer la valeur `bump` dans le programme. Cependant, en les passant explicitement, nous visons à créer le programme le plus optimisé et le plus efficace possible.
 Dans cette implémentation, nous traitons le parsing des données d'instruction de manière plus flexible et à un niveau plus bas que d'habitude. C'est pourquoi nous allons expliquer les raisons qui nous poussent à prendre les décisions suivantes :
 
-<Codeblock lang="rust">
 ```rust
 #[repr(C, packed)]
 pub struct InitializeInstructionData {
@@ -94,7 +91,6 @@ impl TryFrom<&[u8]> for InitializeInstructionData {
     }
 }
 ```
-</Codeblock>
 
 Le champ `authority` dans `InitializeInstructionData` est facultatif et peut être omis pour créer une *pool* immuable.
 
@@ -106,7 +102,6 @@ Nous commençons par désérialiser les `instruction_data` et les `accounts`.
 
 Nous devons ensuite :
 - Créez le compte `Config` à l'aide de l'instruction `CreateAccount` du Programme Système et des *seeds* suivantes :
-<Codeblock lang="rust">
 ```rust
 let seed_binding = self.instruction_data.seed.to_le_bytes();
 let config_seeds = [
@@ -117,10 +112,8 @@ let config_seeds = [
     Seed::from(&self.instruction_data.config_bump),
 ];
 ```
-</Codeblock>
 - Remplissez le compte `Config` en le chargeant à l'aide de `Config::load_mut_unchecked()` puis en le remplissant avec toutes les données nécessaires à l'aide de l'aide `config.set_inner()`.
 - Créez le compte de `Mint` pour la LP à l'aide des instructions `CreateAccount` et `InitializeMint2` et des *seeds* suivantes : 
-<Codeblock lang="rust">
 ```rust
 let mint_lp_seeds = [
     Seed::from(b"mint_lp"),
@@ -128,12 +121,10 @@ let mint_lp_seeds = [
     Seed::from(&self.instruction_data.lp_bump),
 ];
 ```
-</Codeblock>
 
 > La `mint_authority` de `mint_lp` est le compte `config`
 Vous devriez être suffisamment compétent pour le faire vous-même, je vous laisse donc le soin de l'implémenter :
 
-<Codeblock lang="rust">
 ```rust
 pub struct Initialize<'a> {
     pub accounts: InitializeAccounts<'a>,
@@ -164,7 +155,6 @@ impl<'a> Initialize<'a> {
     }
 }
 ```
-</Codeblock>
 
 <ArticleSection name="Sécurité" id="security" level="h2" />
 

--- a/src/app/content/challenges/pinocchio-amm/fr/pages/swap.mdx
+++ b/src/app/content/challenges/pinocchio-amm/fr/pages/swap.mdx
@@ -19,7 +19,6 @@ Voici les comptes nécessaires pour ce contexte :
 
 Ici encore, je vous laisse le soin de l'implémenter :
 
-<Codeblock lang="rust">
 ```rust
 pub struct SwapAccounts<'a> {
     pub user: &'a AccountInfo,
@@ -39,7 +38,6 @@ impl<'a> TryFrom<&'a [AccountInfo]> for SwapAccounts<'a> {
     }
 }
 ```
-</Codeblock>
 
 <ArticleSection name="Données d'Instruction" id="instruction-data" level="h2" />
 
@@ -51,7 +49,6 @@ Voici les données d'instruction que nous devons transmettre :
 
 Nous allons gérer l'implémentation de `SwapInstructionData` de la même manière que l'initialisation. Je vous laisse donc le soin de l'implémenter :
 
-<Codeblock lang="rust">
 ```rust
 pub struct SwapInstructionData {
     pub is_x: bool,
@@ -68,7 +65,6 @@ impl<'a> TryFrom<&'a [u8]> for SwapInstructionData {
     }
 }
 ```
-</Codeblock>
 
 > Assurez-vous que tous les montants, telles que `amount` et `min`, sont supérieurs à zéro et que l'ordre n'a pas encore expiré à l'aide de la sysvar `Clock`.
 
@@ -82,7 +78,6 @@ Nous devons ensuite :
 - Vérifiez que la dérivation de `vault_x` et `vault_y` correspond bien à des Comptes de Jetons Associés.
 - Désérialisez tous les comptes de jetons impliqués et utilisez les données qu'ils contiennent pour calculer le montant des dépôts à l'aide du crate `constant-product-curve` et vérifiez le slippage comme ceci :
 
-<Codeblock lang="rust">
 ```rust
 // Deserialize the token accounts
 let vault_x = unsafe { TokenAccount::from_account_info_unchecked(self.accounts.vault_x)? };
@@ -112,11 +107,9 @@ if swap_result.deposit == 0 || swap_result.withdraw == 0 {
     return Err(ProgramError::InvalidArgument);
 }
 ```
-</Codeblock>
 
 - Créez la logique de transfert en vérifiant la valeur `is_x` et transférez les montants `from` vers les vaults et les montants `to` vers les comptes de jetons de l'utilisateur comme ceci :
 
-<Codeblock lang="rust">
 ```rust
 if self.instruction_data.is_x {
     Transfer {
@@ -141,11 +134,9 @@ if self.instruction_data.is_x {
     .invoke_signed(&signer_seeds)?;
 }
 ```
-</Codeblock>
 
 Vous devriez être suffisamment compétent pour le faire vous-même, je vous laisse donc le soin de l'implémenter :
 
-<Codeblock lang="rust">
 ```rust
 pub struct Swap<'a> {
     pub accounts: SwapAccounts<'a>,
@@ -176,4 +167,3 @@ impl<'a> Swap<'a> {
     }
 }
 ```
-</Codeblock>

--- a/src/app/content/challenges/pinocchio-amm/fr/pages/withdraw.mdx
+++ b/src/app/content/challenges/pinocchio-amm/fr/pages/withdraw.mdx
@@ -22,7 +22,6 @@ Voici les comptes nécessaires pour ce contexte :
 
 Ici encore, je vous laisse le soin de l'implémenter :
 
-<Codeblock lang="rust">
 ```rust
 pub struct WithdrawAccounts<'a> {
     pub user: &'a AccountInfo,
@@ -44,7 +43,6 @@ impl<'a> TryFrom<&'a [AccountInfo]> for WithdrawAccounts<'a> {
     }
 }
 ```
-</Codeblock>
 
 <ArticleSection name="Données d'Instruction" id="instruction-data" level="h2" />
 
@@ -56,7 +54,6 @@ Voici les données d'instruction que nous devons transmettre :
 
 Nous allons gérer l'implémentation de `WithdrawInstructionData` de la même manière que l'initialisation. Je vous laisse donc le soin de l'implémenter :
 
-<Codeblock lang="rust">
 ```rust
 pub struct WithdrawInstructionData {
     pub amount: u64,
@@ -73,7 +70,6 @@ impl<'a> TryFrom<&'a [u8]> for WithdrawInstructionData {
     }
 }
 ```
-</Codeblock>
 
 > Assurez-vous que tous les montants, telles que `amount`, `max_y` et `max_x`, sont supérieurs à zéro et que l'ordre n'a pas encore expiré à l'aide de la sysvar `Clock`.
 
@@ -87,7 +83,6 @@ Nous devons ensuite :
 - Vérifiez que la dérivation de `vault_x` et `vault_y` correspond bien à des Comptes de Jetons Associés.
 - Désérialisez tous les comptes de jetons impliqués et utilisez les données qu'ils contiennent pour calculer le montant des dépôts à l'aide du crate `constant-product-curve` et vérifiez le slippage comme ceci :
 
-<Codeblock lang="rust">
 ```rust
 let mint_lp = unsafe { Mint::from_account_info_unchecked(self.accounts.mint_lp)? };
 let vault_x = unsafe { TokenAccount::from_account_info_unchecked(self.accounts.vault_x)? };
@@ -114,7 +109,6 @@ if !(x >= self.instruction_data.min_x && y >= self.instruction_data.min_y) {
     return Err(ProgramError::InvalidArgument);
 }
 ```
-</Codeblock>
 
 - Transférez les montants des vaults vers les comptes de jetons de l'utilisateur et brûler le montant approprié de jetons LP du compte de jetons de l'utilisateur
 
@@ -122,7 +116,6 @@ if !(x >= self.instruction_data.min_x && y >= self.instruction_data.min_y) {
 
 Vous devriez être suffisamment compétent pour le faire vous-même, je vous laisse donc le soin de l'implémenter :
 
-<Codeblock lang="rust">
 ```rust
 pub struct Withdraw<'a> {
     pub accounts: WithdrawAccounts<'a>,
@@ -154,4 +147,3 @@ impl<'a> Withdraw<'a> {
     }
 }
 ```
-</Codeblock>

--- a/src/app/content/challenges/pinocchio-amm/vi/challenge.mdx
+++ b/src/app/content/challenges/pinocchio-amm/vi/challenge.mdx
@@ -22,31 +22,25 @@ Trong thử thách này, bạn sẽ triển khai một AMM đơn giản với b�
 
 Hãy bắt đầu bằng cách tạo một môi trường Rust mới:
 
-<Codeblock lang="terminal">
 ```bash
 # create workspace
 cargo new blueshift_native_amm --lib --edition 2021
 cd blueshift_native_amm
 ```
-</Codeblock>
 
 Thêm `pinocchio`, `pinocchio-system`, `pinocchio-token`, `pinocchio-associated-token-account` và `constant-product-curve` được tạo bởi [Dean](https://x.com/deanmlittle) để xử lý tất cả tính toán cho AMM của chúng ta:
 
-<Codeblock lang="terminal">
 ```bash
 cargo add pinocchio pinocchio-system pinocchio-token pinocchio-associated-token-account
 cargo add --git="https://github.com/deanmlittle/constant-product-curve" constant-product-curve
 ```
-</Codeblock>
 
 Khai báo các crate type trong `Cargo.toml` để tạo deployment artifact trong `target/deploy`:
 
-<Codeblock lang="toml">
 ```toml
 [lib]
 crate-type = ["lib", "cdylib"]
 ```
-</Codeblock>
 
 Bây giờ bạn đã sẵn sàng để viết chương trình AMM của mình.
 
@@ -103,7 +97,6 @@ src
 
 Entrypoint, nằm trong file `lib.rs` sẽ trông như thế này:
 
-<Codeblock lang="rust">
 ```rust
 use pinocchio::{
     account_info::AccountInfo, entrypoint, program_error::ProgramError, pubkey::Pubkey,
@@ -139,7 +132,6 @@ fn process_instruction(
     }
 }
 ```
-</Codeblock>
 
 <ArticleSection name="State" id="state" level="h2" />
 
@@ -149,7 +141,6 @@ Hãy chia điều này thành ba phần: định nghĩa struct, các hàm hỗ t
 
 Đầu tiên, hãy xem định nghĩa struct:
 
-<Codeblock lang="rust">
 ```rust
 use core::mem::size_of;
 use pinocchio::{account_info::AccountInfo, program_error::ProgramError, pubkey::Pubkey};
@@ -179,7 +170,6 @@ impl Config {
     //...
 }
 ```
-</Codeblock>
 
 Thuộc tính `#[repr(C)]` đảm bảo rằng cấu trúc của chúng ta có thể dự đoán được, bố cục của bộ nhớ tương thích với C duy trì tính nhất quán trên các nền tảng và các phiên bản biên dịch khác nhau của Rust. Điều này rất quan trọng đối với các chương trình on-chain vì dữ liệu phải được serialized và deserialized một cách đáng tin cậy.
 
@@ -201,7 +191,6 @@ Enum `AmmState` định nghĩa các trạng thái có thể của AMM, nó khi�
 
 Các hàm hỗ trợ đọc cung cấp một cách truy cập vào dữ liệu `Config` một cách an toàn và hiệu quả với những kiểm tra phù hợp:
 
-<Codeblock lang="rust">
 ```rust
 impl Config {
     //...
@@ -278,7 +267,6 @@ impl Config {
     pub fn config_bump(&self) -> [u8; 1] { self.config_bump }
 }
 ```
-</Codeblock>
 
 Chức năng chính của các hàm hỗ trợ đọc:
 - Safe Borrowing: Phương thức `load` trả về một `Ref<Self>` quản lý việc vay mượn dữ liệu tài khoản một cách an toàn, ngăn chặn tình trạng chạy đua dữ liệu (data race) và đảm bảo an toàn bộ nhớ.
@@ -289,7 +277,6 @@ Chức năng chính của các hàm hỗ trợ đọc:
 
 Các hàm hỗ trợ ghi cung cấp các phương thức an toàn và được kiểm tra cho việc thay đổi dữ liệu `Config`:
 
-<Codeblock lang="rust">
 ```rust
 impl Config {
     //...
@@ -357,7 +344,6 @@ impl Config {
     }
 }
 ```
-</Codeblock>
 
 Các tính năng chính của các hàm hỗ trợ ghi:
 - Mutable Borrowing: Phương thức `load_mut` trả về `RefMut<Self>` quản lý an toàn việc mutable borrowing từ account data.

--- a/src/app/content/challenges/pinocchio-amm/vi/pages/deposit.mdx
+++ b/src/app/content/challenges/pinocchio-amm/vi/pages/deposit.mdx
@@ -21,7 +21,6 @@ Bên dưới là các tài khoản cần thiết cho ngữ cảnh này:
 
 Ở đây, tôi sẽ để việc triển khai cho bạn:
 
-<Codeblock lang="rust">
 ```rust
 pub struct DepositAccounts<'a> {
     pub user: &'a AccountInfo,
@@ -43,7 +42,6 @@ impl<'a> TryFrom<&'a [AccountInfo]> for DepositAccounts<'a> {
   }
 }
 ```
-</Codeblock>
 
 <ArticleSection name="Dữ liệu cho Instruction" id="instruction-data" level="h2" />
 
@@ -55,7 +53,6 @@ impl<'a> TryFrom<&'a [AccountInfo]> for DepositAccounts<'a> {
 
 Chúng ta sẽ xử lý việc triển khai cho `DepositInstructionData` như khi khởi tạo. Vì vậy, tôi sẽ để việc triển khai cho bạn:
 
-<Codeblock lang="rust">
 ```rust
 pub struct DepositInstructionData {
     pub amount: u64,
@@ -72,7 +69,6 @@ impl<'a> TryFrom<&'a [u8]> for DepositInstructionData {
     }
 }
 ```
-</Codeblock>
 
 > Đảm bảo rằng bất kỳ số lượng nào, như `amount`, `max_y` và `max_x` đều lớn hơn zero và lệnh này chưa hết hạn bằng cách sử dụng `Clock` sysvar.
 
@@ -84,7 +80,6 @@ Chúng ta cần phải:
 - Load tài khoản `Config` để lấy tất cả dữ liệu bên trong nó. Chúng ta có thể làm điều này bằng cách sử dụng hàm hỗ trợ `Config::load()`.
 - Xác định rằng trạng thái của AMM là hợp lệ (nghĩa là nó phải bằng `AmmState::Initialized`).
 - Kiểm tra tài khoản `vault_x` và `vault_y` là các tài khoản token liên kết hợp lệ như thế này:
-<Codeblock lang="rust">
 ```rust
 // Check if the vault_x is valid
 let (vault_x, _) = find_program_address(
@@ -100,9 +95,7 @@ if vault_x.ne(self.accounts.vault_x.key()) {
     return Err(ProgramError::InvalidAccountData);
 }
 ```
-</Codeblock>
 - Deserialize các tài khoản liên quan đến token và sử dụng dữ liệu bên trong chúng để tính toán số lượng token cần deposit sử dụng crate `constant-product-curve` và kiểm tra slippage như thế này: 
-<Codeblock lang="rust">
 ```rust
 // Deserialize the token accounts
 let mint_lp = unsafe { Mint::from_account_info_unchecked(self.accounts.mint_lp)? };
@@ -131,7 +124,6 @@ if !(x <= self.instruction_data.max_x && y <= self.instruction_data.max_y) {
     return Err(ProgramError::InvalidArgument);
 }
 ```
-</Codeblock>
 
 > Nếu đó là lần đầu thực hiện deposit, chúng ta có thể bỏ qua việc tính toán số lượng LP token và số lượng deposit và chỉ sử dụng giá trị mà người dùng đề xuất
 
@@ -139,7 +131,6 @@ if !(x <= self.instruction_data.max_x && y <= self.instruction_data.max_y) {
 
 Bạn đủ khả năng triển khai logic này, vì vậy tôi sẽ để việc triển khai cho bạn:
 
-<Codeblock lang="rust">
 ```rust
 pub struct Deposit<'a> {
     pub accounts: DepositAccounts<'a>,
@@ -171,4 +162,3 @@ impl<'a> Deposit<'a> {
     }
 }
 ```
-</Codeblock>

--- a/src/app/content/challenges/pinocchio-amm/vi/pages/initialize.mdx
+++ b/src/app/content/challenges/pinocchio-amm/vi/pages/initialize.mdx
@@ -18,7 +18,6 @@ Dưới đây là các tài khoản cần thiết cho context này:
 
 Bởi vì không có nhiều thay đổi so với cấu trúc tài khoản thông thường, tôi sẽ để bạn tự thực hiện:
 
-<Codeblock lang="rust">
 ```rust
 pub struct InitializeAccounts<'a> {
     pub initializer: &'a AccountInfo,
@@ -34,7 +33,6 @@ impl<'a> TryFrom<&'a [AccountInfo]> for InitializeAccounts<'a> {
   }
 }
 ```
-</Codeblock>
 
 > Bạn sẽ cần truyền tất cả các tài khoản được thảo luận ở trên, nhưng không phải tất cả chúng đều cần phải được bao gồm trong cấu trúc `InitializeAccounts`, vì bạn có thể không cần tham chiếu trực tiếp đến mỗi tài khoản trong việc triển khai.
 
@@ -53,7 +51,6 @@ impl<'a> TryFrom<&'a [AccountInfo]> for InitializeAccounts<'a> {
 
 Trong khi triển khai, chúng ta sẽ xử lý việc phân tích dữ liệu instruction một cách linh hoạt và cấp thấp hơn thông thường. Do đó, chúng ta sẽ giải thích lý do chúng ta đang đưa ra các quyết định sau:
 
-<Codeblock lang="rust">
 ```rust
 #[repr(C, packed)]
 pub struct InitializeInstructionData {
@@ -96,7 +93,6 @@ impl TryFrom<&[u8]> for InitializeInstructionData {
     }
 }
 ```
-</Codeblock>
 
 Trường authority trong `InitializeInstructionData` là tùy chọn và có thể được bỏ qua để tạo một pool bất biến.
 
@@ -108,7 +104,6 @@ Chúng ta bắt đầu bằng cách deserialize cả `instruction_data` và `acc
 
 Sau đó chúng ta cần:
 - Tạo tài khoản `Config` bằng cách sử dụng instruction `CreateAccount` từ system program và các seed sau:
-<Codeblock lang="rust">
 ```rust
 let seed_binding = self.instruction_data.seed.to_le_bytes();
 let config_seeds = [
@@ -119,10 +114,8 @@ let config_seeds = [
     Seed::from(&self.instruction_data.config_bump),
 ];
 ```
-</Codeblock>
 - Điền thông tin vào tài khoản `Config` bằng cách tải nó sử dụng hàm hỗ trợ `Config::load_mut_unchecked()` và sau đó điền tất cả dữ liệu cần thiết bằng hàm hỗ trợ `config.set_inner()`.
 - Tạo tài khoản `Mint` cho lp bằng cách sử dụng instruction `CreateAccount` và `InitializeMint2` và các seed sau:
-<Codeblock lang="rust">
 ```rust
 let mint_lp_seeds = [
     Seed::from(b"mint_lp"),
@@ -130,13 +123,11 @@ let mint_lp_seeds = [
     Seed::from(&self.instruction_data.lp_bump),
 ];
 ```
-</Codeblock>
 
 > `mint_authority` của `mint_lp` là tài khoản `config`
 
 Bạn đã có đủ trình độ để làm điều này một mình, vì vậy tôi sẽ để việc triển khai cho bạn:
 
-<Codeblock lang="rust">
 ```rust
 pub struct Initialize<'a> {
     pub accounts: InitializeAccounts<'a>,
@@ -167,7 +158,6 @@ impl<'a> Initialize<'a> {
     }
 }
 ```
-</Codeblock>
 
 <ArticleSection name="Bảo mật" id="security" level="h2" />
 

--- a/src/app/content/challenges/pinocchio-amm/vi/pages/swap.mdx
+++ b/src/app/content/challenges/pinocchio-amm/vi/pages/swap.mdx
@@ -19,7 +19,6 @@ Dưới đây là các tài khoản cần thiết cho context này:
 
 Ở đây, một lần nữa, tôi sẽ để việc triển khai cho bạn:
 
-<Codeblock lang="rust">
 ```rust
 pub struct SwapAccounts<'a> {
     pub user: &'a AccountInfo,
@@ -39,7 +38,6 @@ impl<'a> TryFrom<&'a [AccountInfo]> for SwapAccounts<'a> {
     }
 }
 ```
-</Codeblock>
 
 <ArticleSection name="Dữ liệu cho Instruction" id="instruction-data" level="h2" />
 
@@ -51,7 +49,6 @@ impl<'a> TryFrom<&'a [AccountInfo]> for SwapAccounts<'a> {
 
 Chúng ta sẽ xử lý việc triển khai cho `SwapInstructionData` như khởi tạo. Vì vậy tôi sẽ để việc triển khai cho bạn:
 
-<Codeblock lang="rust">
 ```rust
 pub struct SwapInstructionData {
     pub is_x: bool,
@@ -68,7 +65,6 @@ impl<'a> TryFrom<&'a [u8]> for SwapInstructionData {
     }
 }
 ```
-</Codeblock>
 
 > Đảm bảo rằng bất kỳ số lượng nào, như `amount` và `mint` đều lớn hơn zero và lệnh chưa hết hạn bằng cách sử dụng sysvar `Clock`.
 
@@ -81,7 +77,6 @@ Sau đó chúng ta cần:
 - Xác minh rằng `AmmState` hợp lệ (vì vậy nếu nó bằng `AmmState::Initialized`).
 - Kiểm tra việc tạo `vault_x` và `vault_y` để trở thành Associated Token Accounts.
 - Deserialize tất cả các tài khoản token liên quan và sử dụng dữ liệu bên trong chúng để tính toán số lượng cần swap bằng cách sử dụng crate `constant-product-curve` và kiểm tra slippage như thế này:
-<Codeblock lang="rust">
 ```rust
 // Deserialize the token accounts
 let vault_x = unsafe { TokenAccount::from_account_info_unchecked(self.accounts.vault_x)? };
@@ -111,11 +106,9 @@ if swap_result.deposit == 0 || swap_result.withdraw == 0 {
     return Err(ProgramError::InvalidArgument);
 }
 ```
-</Codeblock>
 
 - Tạo logic chuyển khoản kiểm tra giá trị `is_x` và chuyển số lượng `from` đến các vault và số lượng `to` đến tài khoản token của người dùng như thế này:
 
-<Codeblock lang="rust">
 ```rust
 if self.instruction_data.is_x {
     Transfer {
@@ -140,11 +133,9 @@ if self.instruction_data.is_x {
     .invoke_signed(&signer_seeds)?;
 }
 ```
-</Codeblock>
 
 Bạn đủ khả năng triển khai logic này, vì vậy tôi sẽ để việc triển khai cho bạn:
 
-<Codeblock lang="rust">
 ```rust
 pub struct Swap<'a> {
     pub accounts: SwapAccounts<'a>,
@@ -175,4 +166,3 @@ impl<'a> Swap<'a> {
     }
 }
 ```
-</Codeblock>

--- a/src/app/content/challenges/pinocchio-amm/vi/pages/withdraw.mdx
+++ b/src/app/content/challenges/pinocchio-amm/vi/pages/withdraw.mdx
@@ -21,7 +21,6 @@ Dưới đây là các tài khoản cần thiết cho context này:
 
 Ở đây, một lần nữa, tôi sẽ để việc triển khai cho bạn:
 
-<Codeblock lang="rust">
 ```rust
 pub struct WithdrawAccounts<'a> {
     pub user: &'a AccountInfo,
@@ -43,7 +42,6 @@ impl<'a> TryFrom<&'a [AccountInfo]> for WithdrawAccounts<'a> {
     }
 }
 ```
-</Codeblock>
 
 <ArticleSection name="Dữ liệu cho Instruction" id="instruction-data" level="h2" />
 
@@ -55,7 +53,6 @@ impl<'a> TryFrom<&'a [AccountInfo]> for WithdrawAccounts<'a> {
 
 Chúng ta sẽ xử lý việc triển khai cho `WithdrawInstructionData` như khởi tạo. Vì vậy tôi sẽ để việc triển khai cho bạn:
 
-<Codeblock lang="rust">
 ```rust
 pub struct WithdrawInstructionData {
     pub amount: u64,
@@ -72,7 +69,6 @@ impl<'a> TryFrom<&'a [u8]> for WithdrawInstructionData {
     }
 }
 ```
-</Codeblock>
 
 > Đảm bảo rằng bất kỳ số lượng nào, như `amount`, `min_y` và `min_x` đều lớn hơn zero và lệnh chưa hết hạn bằng cách sử dụng sysvar `Clock`.
 
@@ -85,7 +81,6 @@ Sau đó chúng ta cần:
 - Xác minh rằng `AmmState` hợp lệ (vì vậy nếu nó không bằng `AmmState::Disabled`).
 - Kiểm tra việc tạo `vault_x` và `vault_y` để trở thành Associated Token Accounts.
 - Deserialize tất cả các tài khoản token liên quan và sử dụng dữ liệu bên trong chúng để tính toán số lượng cần rút bằng cách sử dụng crate `constant-product-curve` và kiểm tra slippage như thế này:
-<Codeblock lang="rust">
 ```rust
 let mint_lp = unsafe { Mint::from_account_info_unchecked(self.accounts.mint_lp)? };
 let vault_x = unsafe { TokenAccount::from_account_info_unchecked(self.accounts.vault_x)? };
@@ -112,14 +107,12 @@ if !(x <= self.instruction_data.min_x && y <= self.instruction_data.min_y) {
     return Err(ProgramError::InvalidArgument);
 }
 ```
-</Codeblock>
 - Chuyển số lượng từ các vault đến tài khoản token của người dùng và burn số lượng LP token thích hợp từ tài khoản token của người dùng
 
 > `authority` của `vault_x` và `vault_y` là tài khoản `config`
 
 Bạn đủ khả năng triển khai logic này, vì vậy tôi sẽ để việc triển khai cho bạn:
 
-<Codeblock lang="rust">
 ```rust
 pub struct Withdraw<'a> {
     pub accounts: WithdrawAccounts<'a>,
@@ -151,4 +144,3 @@ impl<'a> Withdraw<'a> {
     }
 }
 ```
-</Codeblock>

--- a/src/app/content/challenges/pinocchio-escrow/en/challenge.mdx
+++ b/src/app/content/challenges/pinocchio-escrow/en/challenge.mdx
@@ -1,5 +1,4 @@
 import ArticleSection from "../../../../components/ArticleSection/ArticleSection";
-import { Codeblock } from "../../../../components/Codeblock/Codeblock";
 
 # The Escrow
 
@@ -22,30 +21,24 @@ In this challenge, we're going to implement this concept through three simple bu
 
 Let's start by creating a fresh Rust environment:
 
-<Codeblock lang="terminal">
 ```bash
 # create workspace
 cargo new blueshift_escrow --lib --edition 2021
 cd blueshift_escrow
 ```
-</Codeblock>
 
 Add pinocchio, pinocchio-system, pinocchio-token and pinocchio-associated-token:
 
-<Codeblock lang="terminal">
 ```bash
 cargo add pinocchio pinocchio-system pinocchio-token pinocchio-associated-token-account
 ```
-</Codeblock>
 
 Declare the crate types in `Cargo.toml` to generate deployment artifacts in `target/deploy`:
 
-<Codeblock lang="toml">
 ```toml
 [lib]
 crate-type = ["lib", "cdylib"]
 ```
-</Codeblock>
 
 You're now ready to write your escrow program.
 
@@ -68,7 +61,6 @@ src
 
 The entrypoint, that lives in the `lib.rs` looks very similar to what we did in the last lessons so we're going to go over it very quickly:
 
-<Codeblock lang="rust">
 ```rust
 use pinocchio::{account_info::AccountInfo, entrypoint, program_error::ProgramError, pubkey::Pubkey, ProgramResult};
 entrypoint!(process_instruction);
@@ -100,7 +92,6 @@ fn process_instruction(
     }
 }
 ```
-</Codeblock>
 
 <ArticleSection name="State" id="state" level="h2" />
 
@@ -108,7 +99,6 @@ We're going to move into the `state.rs` where all the data for our `Escrow` live
 
 First, let's look at the struct definition:
 
-<Codeblock lang="rust">
 ```rust
 use pinocchio::{program_error::ProgramError, pubkey::Pubkey};
 use core::mem::size_of;
@@ -123,7 +113,6 @@ pub struct Escrow {
     pub bump: [u8;1]      // PDA bump seed
 }
 ```
-</Codeblock>
 
 The `#[repr(C)]` attribute ensures our struct has a predictable memory layout, which is crucial for on-chain data. Each field serves a specific purpose:
 - **seed**: A random number that allows one maker to create multiple escrows with the same token pair
@@ -135,7 +124,6 @@ The `#[repr(C)]` attribute ensures our struct has a predictable memory layout, w
 
 Now, let's look at the implementation with all its helper methods:
 
-<Codeblock lang="rust">
 ```rust
 impl Escrow {
     pub const LEN: usize = size_of::<u64>() 
@@ -202,7 +190,6 @@ impl Escrow {
     }
 }
 ```
-</Codeblock>
 
 The implementation provides several key features:
 1. **Exact Size Calculation**: `LEN` precisely calculates the account size by summing each field's size

--- a/src/app/content/challenges/pinocchio-escrow/en/pages/make.mdx
+++ b/src/app/content/challenges/pinocchio-escrow/en/pages/make.mdx
@@ -22,7 +22,6 @@ Below are the accounts the context needs:
 
 In code, this looks like:
 
-<Codeblock lang="rust">
 ```rust
 pub struct MakeAccounts<'a> {
   pub maker: &'a AccountInfo,
@@ -63,7 +62,6 @@ impl<'a> TryFrom<&'a [AccountInfo]> for MakeAccounts<'a> {
   }
 }
 ```
-</Codeblock>
 
 <ArticleSection name="Instruction Data" id="instruction-data" level="h2" />
 
@@ -76,7 +74,6 @@ We'll check to make sure the `amount` isn't zero, since that wouldn't make sense
 
 Here's how it looks in code:
 
-<Codeblock lang="rust">
 ```rust
 pub struct MakeInstructionData {
   pub seed: u64,
@@ -109,7 +106,6 @@ impl<'a> TryFrom<&'a [u8]> for MakeInstructionData {
   }
 }
 ```
-</Codeblock>
 
 <ArticleSection name="Instruction Logic" id="instruction-logic" level="h2" />
 
@@ -117,7 +113,6 @@ We begin by initializing the required accounts in the `TryFrom` implementation, 
 
 For this step, we create the `Escrow` account using the `ProgramAccount::init::<Escrow>` trait from the helper functions introduced in the [Introduction to Pinocchio](/en/courses/introduction-to-pinocchio/pinocchio-accounts). Similarly, we initialize the Vault account since it needs to be created fresh:
 
-<Codeblock lang="rust">
 ```rust
 pub struct Make<'a> {
   pub accounts: MakeAccounts<'a>,
@@ -169,11 +164,9 @@ impl<'a> TryFrom<(&'a [u8], &'a [AccountInfo])> for Make<'a> {
   }
 }
 ```
-</Codeblock>
 
 We can now focus on the logic itself that will just be populating the escrow account and then transferring tokens to the vault.
 
-<Codeblock lang="rust">
 ```rust
 impl<'a> Make<'a> {
   pub const DISCRIMINATOR: &'a u8 = &0;
@@ -204,4 +197,3 @@ impl<'a> Make<'a> {
   }
 }
 ```
-</Codeblock>

--- a/src/app/content/challenges/pinocchio-escrow/en/pages/take.mdx
+++ b/src/app/content/challenges/pinocchio-escrow/en/pages/take.mdx
@@ -23,7 +23,6 @@ Below are the accounts the context needs:
 
 And we perform these checks on it:
 
-<Codeblock lang="rust">
 ```rust
 pub struct TakeAccounts<'a> {
   pub taker: &'a AccountInfo,
@@ -72,7 +71,6 @@ impl<'a> TryFrom<&'a [AccountInfo]> for TakeAccounts<'a> {
   }
 }
 ```
-</Codeblock>
 
 <ArticleSection name="Instruction Data" id="instruction-data" level="h2" />
 
@@ -84,7 +82,6 @@ We begin by initializing the required accounts in the `TryFrom` implementation, 
 
 For this step, we ensure both the taker's Token A account and the maker's Token B account are initialized using the `AssociatedTokenAccount::init_if_needed` since we're not sure that they already exists
 
-<Codeblock lang="rust">
 ```rust
 pub struct Take<'a> {
   pub accounts: TakeAccounts<'a>,
@@ -121,14 +118,12 @@ impl<'a> TryFrom<&'a [AccountInfo]> for Take<'a> {
   }
 }
 ```
-</Codeblock>
 
 We can now focus on the logic itself that will:
 - Transfer the tokens from the `taker_ata_b` to the `maker_ata_b`.
 - Transfer the tokens from the `vault` to the `taker_ata_a`.
 - Close the now empty `vault` and withdraw the rent from the account.
 
-<Codeblock lang="rust">
 ```rust
 impl<'a> Take<'a> {
   pub const DISCRIMINATOR: &'a u8 = &1;
@@ -186,4 +181,3 @@ impl<'a> Take<'a> {
   }
 }
 ```
-</Codeblock>

--- a/src/app/content/challenges/pinocchio-escrow/fr/challenge.mdx
+++ b/src/app/content/challenges/pinocchio-escrow/fr/challenge.mdx
@@ -19,30 +19,24 @@ Dans ce défi, nous allons mettre en œuvre ce concept à travers trois instruct
 
 Commençons par créer un nouvel environnement Rust :
 
-<Codeblock lang="terminal">
 ```bash
 # create workspace
 cargo new blueshift_escrow --lib --edition 2021
 cd blueshift_escrow
 ```
-</Codeblock>
 
 Ajoutez ensuite pinocchio, pinocchio-system, pinocchio-token et pinocchio-associated-token :
 
-<Codeblock lang="terminal">
 ```bash
 cargo add pinocchio pinocchio-system pinocchio-token pinocchio-associated-token-account
 ```
-</Codeblock>
 
 Déclarez les types de crate dans `Cargo.toml` pour générer les artefacts de déploiement dans `target/deploy` :
 
-<Codeblock lang="toml">
 ```toml
 [lib]
 crate-type = ["lib", "cdylib"]
 ```
-</Codeblock>
 
 Vous êtes maintenant prêt à écrire votre programme d'escrow.
 
@@ -65,7 +59,6 @@ src
 
 Le point d'entrée, qui se trouve dans `lib.rs`, ressemble beaucoup à ce que nous avons fait dans les dernières leçons, nous allons donc le passer en revue rapidement :
 
-<Codeblock lang="rust">
 ```rust
 use pinocchio::{account_info::AccountInfo, entrypoint, program_error::ProgramError, pubkey::Pubkey, ProgramResult};
 entrypoint!(process_instruction);
@@ -97,7 +90,6 @@ fn process_instruction(
     }
 }
 ```
-</Codeblock>
 
 <ArticleSection name="État (State)" id="state" level="h2" />
 
@@ -105,7 +97,6 @@ Nous allons nous rendre dans le fichier `state.rs` où se trouvent toutes les do
 
 Tout d'abord, intéressons-nous à la définition de la structure :
 
-<Codeblock lang="rust">
 ```rust
 use pinocchio::{program_error::ProgramError, pubkey::Pubkey};
 use core::mem::size_of;
@@ -120,7 +111,6 @@ pub struct Escrow {
     pub bump: [u8;1]      // PDA bump seed
 }
 ```
-</Codeblock>
 
 L'attribut `#[repr(C)]` garantit que notre structure a une configuration mémoire prédictible, ce qui est crucial pour des données on-chain. Chaque champ a une utilité spécifique :
 - **seed**: Un nombre aléatoire qui permet à un créateur de créer plusieurs comptes d'escrow avec la même paire de jetons
@@ -132,7 +122,6 @@ L'attribut `#[repr(C)]` garantit que notre structure a une configuration mémoir
 
 Examinons maintenant l'implémentation et toutes ses fonctions d'aide :
 
-<Codeblock lang="rust">
 ```rust
 impl Escrow {
     pub const LEN: usize = size_of::<u64>() 
@@ -199,7 +188,6 @@ impl Escrow {
     }
 }
 ```
-</Codeblock>
 
 L'implementation présente plusieurs caractéristiques importantes :
 1. **Calcul exact de la taille**: `LEN` calcule précisément la taille du compte en additionnant la taille de chaque champ

--- a/src/app/content/challenges/pinocchio-escrow/fr/pages/make.mdx
+++ b/src/app/content/challenges/pinocchio-escrow/fr/pages/make.mdx
@@ -22,7 +22,6 @@ Voici les comptes dont le contexte a besoin :
 
 Cela se présente donc ainsi :
 
-<Codeblock lang="rust">
 ```rust
 pub struct MakeAccounts<'a> {
   pub maker: &'a AccountInfo,
@@ -63,7 +62,6 @@ impl<'a> TryFrom<&'a [AccountInfo]> for MakeAccounts<'a> {
   }
 }
 ```
-</Codeblock>
 
 <ArticleSection name="Données d'Instruction" id="instruction-data" level="h2" />
 
@@ -76,7 +74,6 @@ Nous vérifierons que l'`amount` n'est pas nul puisque cela n'aurait pas de sens
 
 Voilà ce que cela donne :
 
-<Codeblock lang="rust">
 ```rust
 pub struct MakeInstructionData {
   pub seed: u64,
@@ -109,7 +106,6 @@ impl<'a> TryFrom<&'a [u8]> for MakeInstructionData {
   }
 }
 ```
-</Codeblock>
 
 <ArticleSection name="Logique d'Instruction" id="instruction-logic" level="h2" />
 
@@ -117,7 +113,6 @@ Tout d'abord, après avoir désérialisé les `instruction_data` et les `account
 
 Pour cette étape, nous créons le compte `Escrow` en utilisant le trait `ProgramAccount::init::<Escrow>` des fonctions d'aide introduites dans l'[Introduction à Pinocchio](/en/courses/introduction-to-pinocchio/pinocchio-accounts). De même, nous initialisons le compte du Vault :
 
-<Codeblock lang="rust">
 ```rust
 pub struct Make<'a> {
   pub accounts: MakeAccounts<'a>,
@@ -169,11 +164,9 @@ impl<'a> TryFrom<(&'a [u8], &'a [AccountInfo])> for Make<'a> {
   }
 }
 ```
-</Codeblock>
 
 Nous pouvons maintenant nous concentrer sur la logique elle-même. Celle-ci consiste à remplir le compte d'escrow à transférer les jetons vers le vault.
 
-<Codeblock lang="rust">
 ```rust
 impl<'a> Make<'a> {
   pub const DISCRIMINATOR: &'a u8 = &0;
@@ -204,4 +197,3 @@ impl<'a> Make<'a> {
   }
 }
 ```
-</Codeblock>

--- a/src/app/content/challenges/pinocchio-escrow/fr/pages/take.mdx
+++ b/src/app/content/challenges/pinocchio-escrow/fr/pages/take.mdx
@@ -23,7 +23,6 @@ Voici les comptes dont le contexte a besoin :
 
 Et nous effectuons ces vérifications :
 
-<Codeblock lang="rust">
 ```rust
 pub struct TakeAccounts<'a> {
   pub taker: &'a AccountInfo,
@@ -72,7 +71,6 @@ impl<'a> TryFrom<&'a [AccountInfo]> for TakeAccounts<'a> {
   }
 }
 ```
-</Codeblock>
 
 <ArticleSection name="Données d'Instruction" id="instruction-data" level="h2" />
 
@@ -84,7 +82,6 @@ Tout d'abord, après avoir désérialisé les `accounts` dans l'implémentation 
 
 Pour cette étape, nous nous assurons que le compte de Jeton A du preneur et que le compte de Jeton B du créateur sont initialisés en utilisant `AssociatedTokenAccount::init_if_needed` puisque nous ne sommes pas sûrs qu'ils existent déjà.
 
-<Codeblock lang="rust">
 ```rust
 pub struct Take<'a> {
   pub accounts: TakeAccounts<'a>,
@@ -121,14 +118,12 @@ impl<'a> TryFrom<&'a [AccountInfo]> for Take<'a> {
   }
 }
 ```
-</Codeblock>
 
 Nous pouvons maintenant nous concentrer sur la logique elle-même :
 - Transférer les jetons de `taker_ata_b` vers `maker_ata_b`.
 - Transférer les jetons du `vault` vers `taker_ata_a`.
 - Fermer le `vault` désormais vide et récupérer la rente du compte.
 
-<Codeblock lang="rust">
 ```rust
 impl<'a> Take<'a> {
   pub const DISCRIMINATOR: &'a u8 = &1;
@@ -186,4 +181,3 @@ impl<'a> Take<'a> {
   }
 }
 ```
-</Codeblock>

--- a/src/app/content/challenges/pinocchio-escrow/vi/challenge.mdx
+++ b/src/app/content/challenges/pinocchio-escrow/vi/challenge.mdx
@@ -21,30 +21,24 @@ Trong thử thách này, chúng ta sẽ triển khai khái niệm này thông qu
 
 Hãy bắt đầu bằng cách tạo một môi trường Rust mới:
 
-<Codeblock lang="terminal">
 ```bash
 # create workspace
 cargo new blueshift_escrow --lib --edition 2021
 cd blueshift_escrow
 ```
-</Codeblock>
 
 Thêm pinocchio, pinocchio-system, pinocchio-token và pinocchio-associated-token:
 
-<Codeblock lang="terminal">
 ```bash
 cargo add pinocchio pinocchio-system pinocchio-token pinocchio-associated-token-account
 ```
-</Codeblock>
 
 Khai báo các loại crate trong `Cargo.toml` để tạo ra các artifact triển khai trong `target/deploy`:
 
-<Codeblock lang="toml">
 ```toml
 [lib]
 crate-type = ["lib", "cdylib"]
 ```
-</Codeblock>
 
 Bây giờ bạn đã sẵn sàng để viết chương trình escrow của mình.
 
@@ -67,7 +61,6 @@ src
 
 Điểm vào (entrypoint) nằm trong `lib.rs` trông rất giống với những gì chúng ta đã làm trong các bài học trước, vì vậy chúng ta sẽ xem qua nó một cách nhanh chóng:
 
-<Codeblock lang="rust">
 ```rust
 use pinocchio::{account_info::AccountInfo, entrypoint, program_error::ProgramError, pubkey::Pubkey, ProgramResult};
 entrypoint!(process_instruction);
@@ -99,7 +92,6 @@ fn process_instruction(
     }
 }
 ```
-</Codeblock>
 
 <ArticleSection name="State" id="state" level="h2" />
 
@@ -107,7 +99,6 @@ Chúng ta sẽ chuyển sang `state.rs` nơi chứa tất cả dữ liệu cho `
 
 Đầu tiên, hãy xem định nghĩa struct:
 
-<Codeblock lang="rust">
 ```rust
 use pinocchio::{program_error::ProgramError, pubkey::Pubkey};
 use core::mem::size_of;
@@ -122,7 +113,6 @@ pub struct Escrow {
     pub bump: [u8;1]      // PDA bump seed
 }
 ```
-</Codeblock>
 
 Thuộc tính `#[repr(C)]` đảm bảo struct của chúng ta có bố cục bộ nhớ có thể dự đoán được, điều này rất quan trọng đối với dữ liệu on-chain. Mỗi trường phục vụ một mục đích cụ thể:
 - **seed**: Một số ngẫu nhiên cho phép một maker tạo nhiều escrow với cùng một cặp token
@@ -134,7 +124,6 @@ Thuộc tính `#[repr(C)]` đảm bảo struct của chúng ta có bố cục b�
 
 Bây giờ, hãy xem việc triển khai với tất cả các phương thức hỗ trợ:
 
-<Codeblock lang="rust">
 ```rust
 impl Escrow {
     pub const LEN: usize = size_of::<u64>() 
@@ -201,7 +190,6 @@ impl Escrow {
     }
 }
 ```
-</Codeblock>
 
 Việc triển khai cung cấp một số tính năng chính:
 1. **Tính toán kích thước chính xác**: `LEN` tính toán chính xác kích thước tài khoản bằng cách cộng kích thước của từng trường

--- a/src/app/content/challenges/pinocchio-escrow/vi/pages/make.mdx
+++ b/src/app/content/challenges/pinocchio-escrow/vi/pages/make.mdx
@@ -22,7 +22,6 @@ Dưới đây là các tài khoản mà context cần:
 
 Trong code, điều này trông như sau:
 
-<Codeblock lang="rust">
 ```rust
 pub struct MakeAccounts<'a> {
   pub maker: &'a AccountInfo,
@@ -63,7 +62,6 @@ impl<'a> TryFrom<&'a [AccountInfo]> for MakeAccounts<'a> {
   }
 }
 ```
-</Codeblock>
 
 <ArticleSection name="Dữ liệu cho Instruction" id="instruction-data" level="h2" />
 
@@ -76,7 +74,6 @@ Chúng ta sẽ kiểm tra để đảm bảo `amount` không phải là zero, v�
 
 Đây là cách nó trông trong code:
 
-<Codeblock lang="rust">
 ```rust
 pub struct MakeInstructionData {
   pub seed: u64,
@@ -109,7 +106,6 @@ impl<'a> TryFrom<&'a [u8]> for MakeInstructionData {
   }
 }
 ```
-</Codeblock>
 
 <ArticleSection name="Instruction Logic" id="instruction-logic" level="h2" />
 
@@ -117,7 +113,6 @@ Chúng ta bắt đầu bằng cách khởi tạo các tài khoản cần thiết
 
 Đối với bước này, chúng ta tạo tài khoản `Escrow` bằng cách sử dụng trait `ProgramAccount::init::<Escrow>` từ các hàm hỗ trợ được giới thiệu trong [Giới thiệu về Pinocchio](/vi/courses/introduction-to-pinocchio/pinocchio-accounts). Tương tự, chúng ta khởi tạo tài khoản Vault vì nó cần được tạo mới:
 
-<Codeblock lang="rust">
 ```rust
 pub struct Make<'a> {
   pub accounts: MakeAccounts<'a>,
@@ -169,11 +164,9 @@ impl<'a> TryFrom<(&'a [u8], &'a [AccountInfo])> for Make<'a> {
   }
 }
 ```
-</Codeblock>
 
 Bây giờ chúng ta có thể tập trung vào logic chính, đó là điền thông tin vào tài khoản escrow và sau đó chuyển token vào vault.
 
-<Codeblock lang="rust">
 ```rust
 impl<'a> Make<'a> {
   pub const DISCRIMINATOR: &'a u8 = &0;
@@ -204,4 +197,3 @@ impl<'a> Make<'a> {
   }
 }
 ```
-</Codeblock>

--- a/src/app/content/challenges/pinocchio-escrow/vi/pages/take.mdx
+++ b/src/app/content/challenges/pinocchio-escrow/vi/pages/take.mdx
@@ -23,7 +23,6 @@ Dưới đây là các tài khoản mà context cần:
 
 Và chúng ta thực hiện các kiểm tra này trên nó:
 
-<Codeblock lang="rust">
 ```rust
 pub struct TakeAccounts<'a> {
   pub taker: &'a AccountInfo,
@@ -72,7 +71,6 @@ impl<'a> TryFrom<&'a [AccountInfo]> for TakeAccounts<'a> {
   }
 }
 ```
-</Codeblock>
 
 <ArticleSection name="Dữ liệu cho Instruction" id="instruction-data" level="h2" />
 
@@ -84,7 +82,6 @@ Chúng ta bắt đầu bằng cách khởi tạo các tài khoản cần thiết
 
 Đối với bước này, chúng ta đảm bảo cả tài khoản Token A của taker và tài khoản Token B của maker đều được khởi tạo bằng cách sử dụng `AssociatedTokenAccount::init_if_needed` vì chúng ta không chắc chắn rằng chúng đã tồn tại
 
-<Codeblock lang="rust">
 ```rust
 pub struct Take<'a> {
   pub accounts: TakeAccounts<'a>,
@@ -121,14 +118,12 @@ impl<'a> TryFrom<&'a [AccountInfo]> for Take<'a> {
   }
 }
 ```
-</Codeblock>
 
 Bây giờ chúng ta có thể tập trung vào logic chính sẽ:
 - Chuyển token từ `taker_ata_b` đến `maker_ata_b`.
 - Chuyển token từ `vault` đến `taker_ata_a`.
 - Đóng `vault` hiện đã trống và rút tiền thuê từ tài khoản.
 
-<Codeblock lang="rust">
 ```rust
 impl<'a> Take<'a> {
   pub const DISCRIMINATOR: &'a u8 = &1;
@@ -186,4 +181,3 @@ impl<'a> Take<'a> {
   }
 }
 ```
-</Codeblock>

--- a/src/app/content/challenges/pinocchio-flash-loan/en/challenge.mdx
+++ b/src/app/content/challenges/pinocchio-flash-loan/en/challenge.mdx
@@ -1,5 +1,4 @@
 import { ArticleSection } from "../../../../components/ArticleSection/ArticleSection";
-import { Codeblock } from "../../../../components/Codeblock/Codeblock";
 
 # Pinocchio Flash Loan
 
@@ -26,30 +25,24 @@ If you're new to instruction introspection, we recommend starting with the [Inst
 
 Before you begin, make sure Rust and Pinocchio are installed. Then, run the following in your terminal:
 
-<Codeblock lang="terminal">
 ```bash
 # create workspace
 cargo new blueshift_pinocchio_flash_loan --lib --edition 2021
 cd blueshift_pinocchio_flash_loan
 ```
-</Codeblock>
 
 Add `pinocchio`, `pinocchio-system`, and `pinocchio-token`:
 
-<Codeblock lang="terminal">
 ```bash
 cargo add pinocchio pinocchio-system pinocchio-token
 ```
-</Codeblock>
 
 Declare the crate types in `Cargo.toml` to generate deployment artifacts in `target/deploy`:
 
-<Codeblock lang="toml">
 ```toml
 [lib]
 crate-type = ["lib", "cdylib"]
 ```
-</Codeblock>
 
 You're now ready to write your flash loan program.
 
@@ -71,7 +64,6 @@ src
 
 The entrypoint in `lib.rs` is very similar to what we covered in the [Introduction to Pinocchio Course](/en/courses/introduction-to-pinocchio).
 
-<Codeblock lang="rust">
 ```rust
 use pinocchio::{account_info::AccountInfo, entrypoint, program_error::ProgramError, pubkey::Pubkey, ProgramResult};
 entrypoint!(process_instruction);
@@ -99,13 +91,11 @@ fn process_instruction(
     }
 }
 ```
-</Codeblock>
 
 <ArticleSection name="Helpers" id="helpers" level="h2" />
 
 Before diving into the `loan` and `repay` instructions, let's examine `helpers.rs`:
 
-<Codeblock lang="rust">
 ```rust
 #[repr(C, packed)]
 pub struct LoanData {
@@ -125,6 +115,5 @@ pub fn get_token_amount(data: &[u8]) -> u64 {
     u64::from_le_bytes(data[64..72].try_into().unwrap())
 }
 ```
-</Codeblock>
 
 This file is straightforward. It contains a `LoanData` struct, which we'll use to temporarily store loan data in an account before the loan is repaid. It also provides a `get_token_amount()` helper function to read the token amount from an account.

--- a/src/app/content/challenges/pinocchio-flash-loan/en/pages/borrow.mdx
+++ b/src/app/content/challenges/pinocchio-flash-loan/en/pages/borrow.mdx
@@ -15,7 +15,6 @@ The `loan` instruction is the first half of our flash loan system. It performs f
 
 Here's the implementation:
 
-<Codeblock lang="rust">
 ```rust
 pub struct LoanAccounts<'a> {
     pub borrower: &'a AccountInfo,
@@ -56,7 +55,6 @@ impl<'a> TryFrom<&'a [AccountInfo]> for LoanAccounts<'a> {
     }
 }
 ```
-</Codeblock>
 
 Since `token_accounts` is a dynamic array of accounts, we pass them in similarly to `remaining_accounts`.
 
@@ -71,7 +69,6 @@ Our flash loan program needs to handle variable amounts of data depending on how
 
 Here's the implementation:
 
-<Codeblock lang="rust">
 ```rust
 pub struct LoanInstructionData<'a> {
     pub bump: [u8; 1],
@@ -106,7 +103,6 @@ impl<'a> TryFrom<&'a [u8]> for LoanInstructionData<'a> {
     }
 }
 ```
-</Codeblock>
 
 We use the `split_first` and `split_at_checked` functions to sequentially extract the `bump` and `fee` from the instruction data, allowing us to process the remaining bytes and cast them directly into a `u64` slice using the `core::slice::from_raw_parts()` function for efficient parsing.
 
@@ -116,7 +112,6 @@ We use the `split_first` and `split_at_checked` functions to sequentially extrac
 
 After deserializing `instruction_data` and `accounts`, we check that the number of `amounts` equals the number of `token_accounts` divided by two. This ensures we have the correct number of accounts for the requested loans.
 
-<Codeblock lang="rust">
 ```rust
 pub struct Loan<'a> {
     pub accounts: LoanAccounts<'a>,
@@ -142,13 +137,11 @@ impl<'a> TryFrom<(&'a [u8], &'a [AccountInfo])> for Loan<'a> {
     }
 }
 ```
-</Codeblock>
 
 Next, we create the `signer_seeds` needed to transfer tokens to the borrower and create a `loan` account. The size
 of this account is calculated using `size_of::<LoanData>() * self.instruction_data.amounts.len()` to ensure it can
 hold all the loan data for the transaction.
 
-<Codeblock lang="rust">
 ```rust
 impl<'a> Loan<'a> {
     pub const DISCRIMINATOR: &'a u8 = &0;
@@ -181,11 +174,9 @@ impl<'a> Loan<'a> {
     }
 }
 ```
-</Codeblock>
 
 We then create a mutable slice from the `loan` account's data. We will populate this slice in a `for` loop as we process each loan and its corresponding transfer:
 
-<Codeblock lang="rust">
 ```rust
 let mut loan_data = self.accounts.loan.try_borrow_mut_data()?;
 let loan_entries = unsafe {
@@ -195,11 +186,9 @@ let loan_entries = unsafe {
     )
 };
 ```
-</Codeblock>
 
 Finally, we loop through all the loans. In each iteration, we get the `protocol_token_account` and `borrower_token_account`, calculate the balance due to the protocol, save this data in the `loan` account, and transfer the tokens.
 
-<Codeblock lang="rust">
 ```rust
 for (i, amount) in self.instruction_data.amounts.iter().enumerate() {
     let protocol_token_account = &self.accounts.token_accounts[i * 2];
@@ -228,11 +217,9 @@ for (i, amount) in self.instruction_data.amounts.iter().enumerate() {
     }.invoke_signed(&signer_seeds)?;
 }
 ```
-</Codeblock>
 
 We finish by using instruction introspection to perform the necessary checks. We verify that the last instruction in the transaction is a `repay` instruction and that it uses the same `loan` account as our current `loan` instruction.
 
-<Codeblock lang="rust">
 ```rust
 // Introspecting the Repay instruction
 let instruction_sysvar = unsafe { Instructions::new_unchecked(self.accounts.instruction_sysvar.try_borrow_data()?) };
@@ -251,6 +238,5 @@ if unsafe { instruction.get_account_meta_at_unchecked(1).key } != *self.accounts
     return Err(ProgramError::InvalidInstructionData);
 }
 ```
-</Codeblock>
 
 > Using a `loan` account and structuring the instruction introspection this way ensures that we don't actually need to do any introspection in the `repay` instruction since all repayment checks will be handled by the `loan` account.

--- a/src/app/content/challenges/pinocchio-flash-loan/en/pages/repay.mdx
+++ b/src/app/content/challenges/pinocchio-flash-loan/en/pages/repay.mdx
@@ -10,7 +10,6 @@ The `repay` instruction is the second half of our flash loan system. Thanks to t
 
 Here's the implementation:
 
-<Codeblock lang="rust">
 ```rust
 pub struct RepayAccounts<'a> {
     pub borrower: &'a AccountInfo,
@@ -34,7 +33,6 @@ impl<'a> TryFrom<&'a [AccountInfo]> for RepayAccounts<'a> {
     }
 }
 ```
-</Codeblock>
 
 The `token_accounts` field is a dynamic array of accounts representing the protocol token accounts associated with the borrower's loan.
 
@@ -46,7 +44,6 @@ No instruction data is needed because we use the `balance` field in the `loan` a
 
 We begin by parsing the accounts into the `RepayAccounts` struct.
 
-<Codeblock lang="rust">
 ```rust
 pub struct Repay<'a> {
     pub accounts: RepayAccounts<'a>,
@@ -63,11 +60,9 @@ impl<'a> TryFrom<&'a [AccountInfo]> for Repay<'a> {
 }
 
 ```
-</Codeblock>
 
 Next, we check if all loans have been repaid. We do this by retrieving the number of loans from the `loan` account and iterating through them. For each loan, we verify that the `protocol_token_account` is correct and that its balance is greater than or equal to the amount loaned.
 
-<Codeblock lang="rust">
 ```rust
 impl<'a> Repay<'a> {
     pub const DISCRIMINATOR: &'a u8 = &1;
@@ -102,11 +97,9 @@ impl<'a> Repay<'a> {
     }
 }
 ```
-</Codeblock>
 
 We can then proceed to close the `loan` account and reclaim the rent, as it's no longer needed:
 
-<Codeblock lang="rust">
 ```rust
 drop(loan_data);
 // Close the loan account and give back the lamports to the borrower
@@ -116,6 +109,5 @@ unsafe {
     self.accounts.loan.close_unchecked();
 }
 ```
-</Codeblock>
 
 > As you can see, for optimization purposes and by design, the repayment doesn't happen in this instruction. This is because the `borrower` can choose to repay the token account in another instruction, such as when performing a swap or executing a series of CPIs from their arbitrage program.

--- a/src/app/content/challenges/pinocchio-flash-loan/fr/challenge.mdx
+++ b/src/app/content/challenges/pinocchio-flash-loan/fr/challenge.mdx
@@ -1,5 +1,4 @@
 import { ArticleSection } from "../../../../components/ArticleSection/ArticleSection";
-import { Codeblock } from "../../../../components/Codeblock/Codeblock";
 
 # Flash Loan avec Pinocchio
 
@@ -24,30 +23,24 @@ Si vous êtes novice en matière d'introspection des instructions, nous vous rec
 
 Avant de commencer, assurez-vous que Rust et Pinocchio sont installés. Ensuite, exécutez la commande suivante dans votre terminal :
 
-<Codeblock lang="terminal">
 ```bash
 # create workspace
 cargo new blueshift_pinocchio_flash_loan --lib --edition 2021
 cd blueshift_pinocchio_flash_loan
 ```
-</Codeblock>
 
 Ajoutez `pinocchio`, `pinocchio-system`, et `pinocchio-token`:
 
-<Codeblock lang="terminal">
 ```bash
 cargo add pinocchio pinocchio-system pinocchio-token
 ```
-</Codeblock>
 
 Déclarez les types de crate dans `Cargo.toml` pour générer les artefacts de déploiement dans `target/deploy` :
 
-<Codeblock lang="toml">
 ```toml
 [lib]
 crate-type = ["lib", "cdylib"]
 ```
-</Codeblock>
 
 Vous êtes maintenant prêt à écrire votre programme de prêt flash.
 
@@ -69,7 +62,6 @@ src
 
 Le point d'entrée de `lib.rs` est très similaire à ce que nous avons abordé dans le [Cours d'Introduction à Pinocchio](/en/courses/introduction-to-pinocchio).
 
-<Codeblock lang="rust">
 ```rust
 use pinocchio::{account_info::AccountInfo, entrypoint, program_error::ProgramError, pubkey::Pubkey, ProgramResult};
 entrypoint!(process_instruction);
@@ -97,13 +89,11 @@ fn process_instruction(
     }
 }
 ```
-</Codeblock>
 
 <ArticleSection name="Fonctions d'Aide" id="helpers" level="h2" />
 
 Avant de plonger dans les instructions `loan` et `repay`, intéressons-nous à `helpers.rs` :
 
-<Codeblock lang="rust">
 ```rust
 #[repr(C, packed)]
 pub struct LoanData {
@@ -115,6 +105,5 @@ pub fn get_token_amount(data: &[u8]) -> u64 {
     unsafe { *(data.as_ptr().add(64) as *const u64) }
 }
 ```
-</Codeblock>
 
 Ce dossier est simple. Il contient une structure `LoanData` que nous utiliserons pour stocker temporairement les données du prêt dans un compte avant qu'il ne soit remboursé. Il fournit également une fonction d'aide `get_token_amount()` qui permet de lire le nombre de jetons d'un compte.

--- a/src/app/content/challenges/pinocchio-flash-loan/fr/pages/borrow.mdx
+++ b/src/app/content/challenges/pinocchio-flash-loan/fr/pages/borrow.mdx
@@ -15,7 +15,6 @@ L'instruction `loan` est la première partie de notre système de prêt flash. I
 
 Voici l'implémentation:
 
-<Codeblock lang="rust">
 ```rust
 pub struct LoanAccounts<'a> {
     pub borrower: &'a AccountInfo,
@@ -56,7 +55,6 @@ impl<'a> TryFrom<&'a [AccountInfo]> for LoanAccounts<'a> {
     }
 }
 ```
-</Codeblock>
 
 Étant donné que `token_accounts` est un tableau dynamique de comptes, nous les transmettons de la même manière que les `remaining_accounts`.
 
@@ -71,7 +69,6 @@ Notre programme de prêts flash doit traiter des quantités variables de donnée
 
 Voici l'implémentation :
 
-<Codeblock lang="rust">
 ```rust
 pub struct LoanInstructionData<'a> {
     pub bump: [u8; 1],
@@ -106,7 +103,6 @@ impl<'a> TryFrom<&'a [u8]> for LoanInstructionData<'a> {
     }
 }
 ```
-</Codeblock>
 
 Nous utilisons les fonctions `split_first` et `split_at_checked` pour extraire séquentiellement `bump` et `fee` des données d'instruction, ce qui nous permet de traiter les octets restants et de les convertir directement en un *slice* `u64` à l'aide de la fonction `core::slice::from_raw_parts()` pour un *parsing* efficace.
 
@@ -116,7 +112,6 @@ Nous utilisons les fonctions `split_first` et `split_at_checked` pour extraire s
 
 Après avoir désérialisé `instruction_data` et `accounts`, nous vérifions que le nombre d'`amounts` est égal aux `token_accounts` divisé par deux. Cela nous permet de nous assurer que nous disposons du nombre correct de comptes pour les prêts demandés.
 
-<Codeblock lang="rust">
 ```rust
 pub struct Loan<'a> {
     pub accounts: LoanAccounts<'a>,
@@ -142,11 +137,9 @@ impl<'a> TryFrom<(&'a [u8], &'a [AccountInfo])> for Loan<'a> {
     }
 }
 ```
-</Codeblock>
 
 Ensuite, nous créons les `signer_seeds` nécessaires pour transférer les jetons à l'emprunteur et créer un compte `loan`. La taille de ce compte est calculée à l'aide de `size_of::<LoanData>() * self.instruction_data.amounts.len()` pour s'assurer qu'il peut contenir toutes les données relatives au prêt de la transaction.
 
-<Codeblock lang="rust">
 ```rust
 impl<'a> Loan<'a> {
     pub const DISCRIMINATOR: &'a u8 = &0;
@@ -179,11 +172,9 @@ impl<'a> Loan<'a> {
     }
 }
 ```
-</Codeblock>
 
 Nous créons ensuite une *slice* mutable à partir des données du compte `loan`. Nous remplirons cette *slice* dans une boucle `for` au fur et à mesure que nous traiterons chaque prêt et son transfert correspondant :
 
-<Codeblock lang="rust">
 ```rust
 let mut loan_data = self.accounts.loan.try_borrow_mut_data()?;
 let loan_entries = unsafe {
@@ -193,11 +184,9 @@ let loan_entries = unsafe {
     )
 };
 ```
-</Codeblock>
 
 Enfin, nous parcourons tous les prêts. À chaque itération, nous récupérons `protocol_token_account` et `borrower_token_account`, calculons le montant dû au protocole, enregistrons ces données dans le compte `loan` et transférons les jetons.
 
-<Codeblock lang="rust">
 ```rust
 for (i, amount) in self.instruction_data.amounts.iter().enumerate() {
     let protocol_token_account = &self.accounts.token_accounts[i * 2];
@@ -226,11 +215,9 @@ for (i, amount) in self.instruction_data.amounts.iter().enumerate() {
     }.invoke_signed(&signer_seeds)?;
 }
 ```
-</Codeblock>
 
 Nous terminons en utilisant l'introspection des instructions pour effectuer les vérifications nécessaires. Nous vérifions que la dernière instruction de la transaction est une instruction `repay` et qu'elle utilise le même compte `loan` que notre instruction `loan` actuelle.
 
-<Codeblock lang="rust">
 ```rust   
 // Introspecting the Repay instruction
 let instruction_sysvar = unsafe { Instructions::new_unchecked(self.accounts.instruction_sysvar.try_borrow_data()?) };
@@ -249,6 +236,5 @@ if unsafe { instruction.get_account_meta_at_unchecked(1).key } != *self.accounts
     return Err(ProgramError::InvalidInstructionData);
 }
 ```
-</Codeblock>
 
 > Utiliser un compte `loan` et structurer l'introspection des instructions de cette manière garantit que nous n'avons pas besoin d'effectuer d'introspection dans l'instruction `repay` puisque toutes les vérifications de remboursement seront gérées par le compte `loan`.

--- a/src/app/content/challenges/pinocchio-flash-loan/fr/pages/repay.mdx
+++ b/src/app/content/challenges/pinocchio-flash-loan/fr/pages/repay.mdx
@@ -10,7 +10,6 @@ L'instruction `repay` est la seconde partie de notre système de prêt flash. Gr
 
 Voici l'implémentation:
 
-<Codeblock lang="rust">
 ```rust
 pub struct RepayAccounts<'a> {
     pub borrower: &'a AccountInfo,
@@ -34,7 +33,6 @@ impl<'a> TryFrom<&'a [AccountInfo]> for RepayAccounts<'a> {
     }
 }
 ```
-</Codeblock>
 
 Le champ `token_accounts` est un tableau dynamique de comptes représentant les comptes de jetons du protocole associés au prêt de l'emprunteur.
 
@@ -46,7 +44,6 @@ Aucune donnée d'instruction n'est nécessaire puisque nous utilisons le champ `
 
 Nous commençons par *parser* les comptes dans la structure `RepayAccounts`.
 
-<Codeblock lang="rust">
 ```rust
 pub struct Repay<'a> {
     pub accounts: RepayAccounts<'a>,
@@ -63,11 +60,9 @@ impl<'a> TryFrom<&'a [AccountInfo]> for Repay<'a> {
 }
 
 ```
-</Codeblock>
 
 Ensuite, nous vérifions si tous les prêts ont été remboursés. Pour ce faire, nous récupérons le nombre de prêts à partir du compte `loan` et les parcourons un par un. Pour chaque prêt, nous vérifions que `protocol_token_account` est correct et que son solde est supérieur ou égal au montant prêté.
 
-<Codeblock lang="rust">
 ```rust
 impl<'a> Repay<'a> {
     pub const DISCRIMINATOR: &'a u8 = &1;
@@ -102,11 +97,9 @@ impl<'a> Repay<'a> {
     }
 }
 ```
-</Codeblock>
 
 Nous pouvons alors procéder à la clôture du compte `loan` et récupérer la rente puisqu'il n'est plus nécessaire :
 
-<Codeblock lang="rust">
 ```rust
 drop(loan_data);
 // Close the loan account and give back the lamports to the borrower
@@ -116,6 +109,5 @@ unsafe {
     self.accounts.loan.close_unchecked();
 }
 ```
-</Codeblock>
 
 > Comme vous pouvez le constater, à des fins d'optimisation et de conception, le remboursement n'est pas effectué dans cette instruction. Cela s'explique par le fait que le `borrower` peut choisir de rembourser le compte de jetons dans une autre instruction. Par exemple, lorsqu'il effectue un échange ou exécute une série de CPIs depuis son programme d'arbitrage.

--- a/src/app/content/challenges/pinocchio-flash-loan/vi/challenge.mdx
+++ b/src/app/content/challenges/pinocchio-flash-loan/vi/challenge.mdx
@@ -1,5 +1,4 @@
 import { ArticleSection } from "../../../../components/ArticleSection/ArticleSection";
-import { Codeblock } from "../../../../components/Codeblock/Codeblock";
 
 # Pinocchio Flash Loan
 
@@ -26,30 +25,24 @@ Nếu bạn mới làm quen với instruction introspection, chúng tôi khuyên
 
 Trước khi bắt đầu, hãy đảm bảo Rust và Pinocchio đã được cài đặt. Sau đó, chạy lệnh sau trong terminal của bạn:
 
-<Codeblock lang="terminal">
 ```bash
 # create workspace
 cargo new blueshift_pinocchio_flash_loan --lib --edition 2021
 cd blueshift_pinocchio_flash_loan
 ```
-</Codeblock>
 
 Thêm `pinocchio`, `pinocchio-system`, và `pinocchio-token`:
 
-<Codeblock lang="terminal">
 ```bash
 cargo add pinocchio pinocchio-system pinocchio-token
 ```
-</Codeblock>
 
 Khai báo các loại crate trong `Cargo.toml` để tạo ra các artifact triển khai trong `target/deploy`:
 
-<Codeblock lang="toml">
 ```toml
 [lib]
 crate-type = ["lib", "cdylib"]
 ```
-</Codeblock>
 
 Bây giờ bạn đã sẵn sàng để viết chương trình flash loan của mình.
 
@@ -71,7 +64,6 @@ src
 
 Entrypoint trong `lib.rs` rất giống với những gì chúng ta đã đề cập trong [Khóa học Giới thiệu về Pinocchio](/vi/courses/introduction-to-pinocchio).
 
-<Codeblock lang="rust">
 ```rust
 use pinocchio::{account_info::AccountInfo, entrypoint, program_error::ProgramError, pubkey::Pubkey, ProgramResult};
 entrypoint!(process_instruction);
@@ -99,13 +91,11 @@ fn process_instruction(
     }
 }
 ```
-</Codeblock>
 
 <ArticleSection name="Các hàm hỗ trợ" id="helpers" level="h2" />
 
 Trước khi đi sâu vào các instruction `loan` và `repay`, hãy xem xét `helpers.rs`:
 
-<Codeblock lang="rust">
 ```rust
 #[repr(C, packed)]
 pub struct LoanData {
@@ -125,6 +115,5 @@ pub fn get_token_amount(data: &[u8]) -> u64 {
     u64::from_le_bytes(data[64..72].try_into().unwrap())
 }
 ```
-</Codeblock>
 
 File này khá đơn giản. Nó chứa một struct `LoanData`, mà chúng ta sẽ sử dụng để tạm thời lưu trữ dữ liệu khoản vay trong một tài khoản trước khi khoản vay được trả lại. Nó cũng cung cấp một hàm hỗ trợ `get_token_amount()` để đọc số lượng token từ một tài khoản.

--- a/src/app/content/challenges/pinocchio-flash-loan/vi/pages/borrow.mdx
+++ b/src/app/content/challenges/pinocchio-flash-loan/vi/pages/borrow.mdx
@@ -15,7 +15,6 @@ Lệnh `loan` (vay) là nửa đầu của hệ thống flash loan. Nó thực h
 
 Đây là cách triển khai:
 
-<Codeblock lang="rust">
 ```rust
 pub struct LoanAccounts<'a> {
     pub borrower: &'a AccountInfo,
@@ -56,7 +55,6 @@ impl<'a> TryFrom<&'a [AccountInfo]> for LoanAccounts<'a> {
     }
 }
 ```
-</Codeblock>
 
 Vì `token_accounts` là một mảng động các tài khoản, chúng ta truyền chúng vào tương tự như `remaining_accounts`.
 
@@ -71,7 +69,6 @@ Chương trình flash loan của chúng ta cần xử lý lượng dữ liệu t
 
 Đây là cách triển khai:
 
-<Codeblock lang="rust">
 ```rust
 pub struct LoanInstructionData<'a> {
     pub bump: [u8; 1],
@@ -106,7 +103,6 @@ impl<'a> TryFrom<&'a [u8]> for LoanInstructionData<'a> {
     }
 }
 ```
-</Codeblock>
 
 Chúng ta sử dụng các hàm `split_first` và `split_at_checked` để tuần tự trích xuất `bump` và `fee` từ dữ liệu lệnh, cho phép chúng ta xử lý các byte còn lại và chuyển đổi chúng trực tiếp thành một slice `u64` bằng cách sử dụng hàm `core::slice::from_raw_parts()` để phân tích cú pháp hiệu quả.
 
@@ -116,7 +112,6 @@ Chúng ta sử dụng các hàm `split_first` và `split_at_checked` để tuầ
 
 Sau khi giải tuần tự hóa `instruction_data` và `accounts`, chúng ta kiểm tra rằng số lượng `amounts` bằng số lượng `token_accounts` chia cho hai. Điều này đảm bảo chúng ta có đúng số lượng tài khoản cho các khoản vay được yêu cầu.
 
-<Codeblock lang="rust">
 ```rust
 pub struct Loan<'a> {
     pub accounts: LoanAccounts<'a>,
@@ -142,13 +137,11 @@ impl<'a> TryFrom<(&'a [u8], &'a [AccountInfo])> for Loan<'a> {
     }
 }
 ```
-</Codeblock>
 
 Tiếp theo, chúng ta tạo `signer_seeds` cần thiết để chuyển token cho người vay và tạo tài khoản `loan`. Kích thước
 của tài khoản này được tính bằng `size_of::<LoanData>() * self.instruction_data.amounts.len()` để đảm bảo nó có thể
 chứa tất cả dữ liệu khoản vay cho giao dịch.
 
-<Codeblock lang="rust">
 ```rust
 impl<'a> Loan<'a> {
     pub const DISCRIMINATOR: &'a u8 = &0;
@@ -181,11 +174,9 @@ impl<'a> Loan<'a> {
     }
 }
 ```
-</Codeblock>
 
 Sau đó chúng ta tạo một slice có thể thay đổi từ dữ liệu của tài khoản `loan`. Chúng ta sẽ điền vào slice này trong một vòng lặp `for` khi xử lý từng khoản vay và việc chuyển tiền tương ứng:
 
-<Codeblock lang="rust">
 ```rust
 let mut loan_data = self.accounts.loan.try_borrow_mut_data()?;
 let loan_entries = unsafe {
@@ -195,11 +186,9 @@ let loan_entries = unsafe {
     )
 };
 ```
-</Codeblock>
 
 Cuối cùng, chúng ta lặp qua tất cả các khoản vay. Trong mỗi lần lặp, chúng ta lấy `protocol_token_account` và `borrower_token_account`, tính toán số dư mà giao thức cần có, lưu dữ liệu này trong tài khoản `loan`, và chuyển token.
 
-<Codeblock lang="rust">
 ```rust
 for (i, amount) in self.instruction_data.amounts.iter().enumerate() {
     let protocol_token_account = &self.accounts.token_accounts[i * 2];
@@ -228,11 +217,9 @@ for (i, amount) in self.instruction_data.amounts.iter().enumerate() {
     }.invoke_signed(&signer_seeds)?;
 }
 ```
-</Codeblock>
 
 Chúng ta kết thúc bằng cách sử dụng instruction introspection để thực hiện các kiểm tra cần thiết. Chúng ta xác minh rằng lệnh cuối cùng trong giao dịch là một lệnh `repay` và nó sử dụng cùng tài khoản `loan` như lệnh `loan` hiện tại của chúng ta.
 
-<Codeblock lang="rust">
 ```rust
 // Introspecting lệnh Repay
 let instruction_sysvar = unsafe { Instructions::new_unchecked(self.accounts.instruction_sysvar.try_borrow_data()?) };
@@ -251,6 +238,5 @@ if unsafe { instruction.get_account_meta_at_unchecked(1).key } != *self.accounts
     return Err(ProgramError::InvalidInstructionData);
 }
 ```
-</Codeblock>
 
 > Việc sử dụng tài khoản `loan` và cấu trúc instruction introspection theo cách này đảm bảo rằng chúng ta thực sự không cần phải thực hiện bất kỳ introspection nào trong lệnh `repay` vì tất cả các kiểm tra hoàn trả sẽ được xử lý bởi tài khoản `loan`.

--- a/src/app/content/challenges/pinocchio-flash-loan/vi/pages/repay.mdx
+++ b/src/app/content/challenges/pinocchio-flash-loan/vi/pages/repay.mdx
@@ -10,7 +10,6 @@ Lệnh `repay` (hoàn trả) là nửa thứ hai của hệ thống flash loan. 
 
 Đây là cách triển khai:
 
-<Codeblock lang="rust">
 ```rust
 pub struct RepayAccounts<'a> {
     pub borrower: &'a AccountInfo,
@@ -34,7 +33,6 @@ impl<'a> TryFrom<&'a [AccountInfo]> for RepayAccounts<'a> {
     }
 }
 ```
-</Codeblock>
 
 Trường `token_accounts` là một mảng động các tài khoản đại diện cho các tài khoản token giao thức liên quan đến khoản vay của người vay.
 
@@ -46,7 +44,6 @@ Không cần dữ liệu cho Instruction nào vì chúng ta sử dụng trườn
 
 Chúng ta bắt đầu bằng cách phân tích các tài khoản thành struct `RepayAccounts`.
 
-<Codeblock lang="rust">
 ```rust
 pub struct Repay<'a> {
     pub accounts: RepayAccounts<'a>,
@@ -63,11 +60,9 @@ impl<'a> TryFrom<&'a [AccountInfo]> for Repay<'a> {
 }
 
 ```
-</Codeblock>
 
 Tiếp theo, chúng ta kiểm tra xem tất cả các khoản vay đã được hoàn trả hay chưa. Chúng ta thực hiện điều này bằng cách lấy số lượng khoản vay từ tài khoản `loan` và lặp qua chúng. Đối với mỗi khoản vay, chúng ta xác minh rằng `protocol_token_account` là đúng và số dư của nó lớn hơn hoặc bằng số tiền đã vay.
 
-<Codeblock lang="rust">
 ```rust
 impl<'a> Repay<'a> {
     pub const DISCRIMINATOR: &'a u8 = &1;
@@ -102,11 +97,9 @@ impl<'a> Repay<'a> {
     }
 }
 ```
-</Codeblock>
 
 Sau đó chúng ta có thể tiến hành đóng tài khoản `loan` và thu hồi tiền thuê, vì nó không còn cần thiết nữa:
 
-<Codeblock lang="rust">
 ```rust
 drop(loan_data);
 // Close the loan account and give back the lamports to the borrower
@@ -116,6 +109,5 @@ unsafe {
     self.accounts.loan.close_unchecked();
 }
 ```
-</Codeblock>
 
 > Như bạn có thể thấy, vì mục đích tối ưu hóa và theo thiết kế, việc hoàn trả không xảy ra trong lệnh này. Điều này là do `borrower` có thể chọn hoàn trả tài khoản token trong một lệnh khác, chẳng hạn như khi thực hiện swap hoặc thực thi một loạt CPI từ chương trình arbitrage của họ.

--- a/src/app/content/challenges/pinocchio-quantum-vault/en/challenge.mdx
+++ b/src/app/content/challenges/pinocchio-quantum-vault/en/challenge.mdx
@@ -1,5 +1,4 @@
 import { ArticleSection } from "../../../../components/ArticleSection/ArticleSection";
-import { Codeblock } from "../../../../components/Codeblock/Codeblock";
 
 # The Quantum Vault
 
@@ -17,30 +16,24 @@ In this challenge, we'll update the simple lamport vault that we built in the [P
 
 Before you begin, make sure Rust and Pinocchio are installed. Then, run the following in your terminal:
 
-<Codeblock lang="terminal">
 ```bash
 # create workspace
 cargo new blueshift-pinocchio-quantum-vault --lib --edition 2021
 cd blueshift-pinocchio-quantum-vault
 ```
-</Codeblock>
 
 Add `pinocchio`, `pinocchio-system`, and `solana-nostd-sha256` and `solana-winternitz`:
 
-<Codeblock lang="terminal">
 ```bash
 cargo add pinocchio pinocchio-system solana-nostd-sha256 solana-winternitz
 ```
-</Codeblock>
 
 Declare the crate types in `Cargo.toml` to generate deployment artifacts in `target/deploy`:
 
-<Codeblock lang="toml">
 ```toml
 [lib]
 crate-type = ["lib", "cdylib"]
 ```
-</Codeblock>
 
 You're now ready to write your quantum vault program.
 
@@ -62,7 +55,6 @@ src
 
 The entrypoint in `lib.rs` is very similar to what we covered in the [Introduction to Pinocchio Course](/en/courses/introduction-to-pinocchio).
 
-<Codeblock lang="rust">
 ```rust
 pub mod instructions;
 use instructions::*;
@@ -95,6 +87,5 @@ fn process_instruction(
     }
 }
 ```
-</Codeblock>
 
 We don't need any state setup for this, so we're just going to move into creating our instructions.

--- a/src/app/content/challenges/pinocchio-quantum-vault/en/pages/close.mdx
+++ b/src/app/content/challenges/pinocchio-quantum-vault/en/pages/close.mdx
@@ -13,7 +13,6 @@ The instruction requires three accounts:
 
 Here's how it looks in code:
 
-<Codeblock lang="rust">
 ```rust
 pub struct CloseVaultAccounts<'a> {
     pub vault: &'a AccountInfo,
@@ -33,7 +32,6 @@ impl<'a> TryFrom<&'a [AccountInfo]> for CloseVaultAccounts<'a> {
 }
 
 ```
-</Codeblock>
 
 > Account validation is handled by the runtime. If accounts don't meet requirements (mutability), the instruction will fail automatically.
 
@@ -45,7 +43,6 @@ Two pieces of data are required:
 
 Here's how it looks in code:
 
-<Codeblock lang="rust">
 ```rust
 pub struct CloseVaultInstructionData {
     pub signature: WinternitzSignature,
@@ -72,7 +69,6 @@ impl<'a> TryFrom<&'a [u8]> for CloseVaultInstructionData {
     }
 }
 ```
-</Codeblock>
 
 <ArticleSection name="Instruction Logic" id="instruction-logic" level="h2" />
 
@@ -90,7 +86,6 @@ The verification process follows these steps:
 
 Here's how it looks in code:
 
-<Codeblock lang="rust">
 ```rust
 pub struct CloseVault<'a> {
     pub accounts: CloseVaultAccounts<'a>,
@@ -133,6 +128,5 @@ impl<'a> CloseVault<'a> {
     }
 }
 ```
-</Codeblock>
 
 > Reconstructing the message prevents signature replay attacks where malicious actors substitute different recipient accounts while MEV-ing valid signatures captured from the mempool.

--- a/src/app/content/challenges/pinocchio-quantum-vault/en/pages/open.mdx
+++ b/src/app/content/challenges/pinocchio-quantum-vault/en/pages/open.mdx
@@ -16,7 +16,6 @@ The instruction requires these accounts:
 
 In code, this looks like:
 
-<Codeblock lang="rust">
 ```rust
 pub struct OpenVaultAccounts<'a> {
     pub payer: &'a AccountInfo,
@@ -35,7 +34,6 @@ impl<'a> TryFrom<&'a [AccountInfo]> for OpenVaultAccounts<'a> {
     }
 }
 ```
-</Codeblock>
 
 > Account validation is handled by the `CreateAccount` CPI. If accounts don't meet requirements (signer, mutability, executability), the instruction will fail automatically.
 
@@ -49,7 +47,6 @@ Two pieces of data are required:
 
 Here's how it looks in code:
 
-<Codeblock lang="rust">
 ```rust
 pub struct OpenVaultInstructionData {
     pub hash: [u8; 32],
@@ -71,7 +68,6 @@ impl<'a> TryFrom<&'a [u8]> for OpenVaultInstructionData {
     }
 }
 ```
-</Codeblock>
 
 > Here again, invalid parameters are self-correcting: passing a wrong hashes brick the vault, passing a wrong bumps fail PDA derivation.
 
@@ -83,7 +79,6 @@ The instruction creates an empty PDA assigned to our program. While the account 
 
 Here's how it looks in code:
 
-<Codeblock lang="rust">
 ```rust
 pub struct OpenVault<'a> {
     pub accounts: OpenVaultAccounts<'a>,
@@ -120,6 +115,5 @@ impl<'a> OpenVault<'a> {
     }
 }
 ```
-</Codeblock>
 
 > This instruction only creates the vault structure. Deposits are handled separately through simple lamport transfers to the vault account.

--- a/src/app/content/challenges/pinocchio-quantum-vault/en/pages/split.mdx
+++ b/src/app/content/challenges/pinocchio-quantum-vault/en/pages/split.mdx
@@ -18,7 +18,6 @@ The `refund` account is often a new quantum vault with a fresh Winternitz keypai
 
 Here's how it looks in code:
 
-<Codeblock lang="rust">
 ```rust
 pub struct SplitVaultAccounts<'a> {
     pub vault: &'a AccountInfo,
@@ -38,7 +37,6 @@ impl<'a> TryFrom<&'a [AccountInfo]> for SplitVaultAccounts<'a> {
     }
 }
 ```
-</Codeblock>
 
 > Account validation is handled by the runtime. If accounts don't meet requirements (mutability), the instruction will fail automatically.
 
@@ -51,7 +49,6 @@ Three pieces of data are required:
 
 Here's how it looks in code:
 
-<Codeblock lang="rust">
 ```rust
 pub struct SplitVaultInstructionData {
     pub signature: WinternitzSignature,
@@ -80,7 +77,6 @@ impl<'a> TryFrom<&'a [u8]> for SplitVaultInstructionData {
     }
 }
 ```
-</Codeblock>
 
 <ArticleSection name="Instruction Logic" id="instruction-logic" level="h2" />
 
@@ -98,7 +94,6 @@ The verification process follows these steps:
 
 Here's how it looks in code:
 
-<Codeblock lang="rust">
 ```rust
 pub struct SplitVault<'a> {
     pub accounts: SplitVaultAccounts<'a>,
@@ -149,6 +144,5 @@ impl<'a> SplitVault<'a> {
     }
 }
 ```
-</Codeblock>
 
 > Reconstructing the message prevents signature replay attacks where malicious actors substitute different recipient accounts while MEV-ing valid signatures captured from the mempool.

--- a/src/app/content/challenges/pinocchio-quantum-vault/vi/challenge.mdx
+++ b/src/app/content/challenges/pinocchio-quantum-vault/vi/challenge.mdx
@@ -1,5 +1,4 @@
 import { ArticleSection } from "../../../../components/ArticleSection/ArticleSection";
-import { Codeblock } from "../../../../components/Codeblock/Codeblock";
 
 # Vault lượng tử
 
@@ -17,30 +16,24 @@ Trong thử thách này, chúng ta sẽ cập nhật vault lamport đơn giản 
 
 Trước khi bắt đầu, hãy đảm bảo rằng Rust và Pinocchio đã được cài đặt. Sau đó, chạy lệnh sau trong terminal của bạn:
 
-<Codeblock lang="terminal">
 ```bash
 # create workspace
 cargo new blueshift-pinocchio-quantum-vault --lib --edition 2021
 cd blueshift-pinocchio-quantum-vault
 ```
-</Codeblock>
 
 Thêm `pinocchio`, `pinocchio-system`, và `solana-nostd-sha256` và `solana-winternitz`:
 
-<Codeblock lang="terminal">
 ```bash
 cargo add pinocchio pinocchio-system solana-nostd-sha256 solana-winternitz
 ```
-</Codeblock>
 
 Khai báo crate types trong `Cargo.toml` để sinh ra các tập tin triển khai trong `target/deploy`:
 
-<Codeblock lang="toml">
 ```toml
 [lib]
 crate-type = ["lib", "cdylib"]
 ```
-</Codeblock>
 
 Bạn đã sẵn sàng để viết chương trình vault lượng tử của mình.
 
@@ -62,7 +55,6 @@ src
 
 Entrypoint trong tệp `lib.rs` rất giống với những gì chúng tôi đã đề cập trong [Khóa học Giới thiệu về Pinocchio](/vi/courses/introduction-to-pinocchio).
 
-<Codeblock lang="rust">
 ```rust
 pub mod instructions;
 use instructions::*;
@@ -95,6 +87,5 @@ fn process_instruction(
     }
 }
 ```
-</Codeblock>
 
 Chúng tôi không cần bất kỳ thiết lập trạng thái nào ở đây, vì vậy chúng tôi chỉ cần chuyển sang việc tạo các instruction của mình.

--- a/src/app/content/challenges/pinocchio-quantum-vault/vi/pages/close.mdx
+++ b/src/app/content/challenges/pinocchio-quantum-vault/vi/pages/close.mdx
@@ -13,7 +13,6 @@ Instruction yêu cầu 2 account:
 
 Mã sẽ trông như thế này:
 
-<Codeblock lang="rust">
 ```rust
 pub struct CloseVaultAccounts<'a> {
     pub vault: &'a AccountInfo,
@@ -33,7 +32,6 @@ impl<'a> TryFrom<&'a [AccountInfo]> for CloseVaultAccounts<'a> {
 }
 
 ```
-</Codeblock>
 
 > Việc xác minh account được xử lý bởi runtime. Nếu các account không đáp ứng yêu cầu (khả năng có thể sửa đổi), instruction sẽ tự động thất bại.
 
@@ -45,7 +43,6 @@ Hai phần dữ liệu là cần thiết:
 
 Mã sẽ trông như thế này:
 
-<Codeblock lang="rust">
 ```rust
 pub struct CloseVaultInstructionData {
     pub signature: WinternitzSignature,
@@ -72,7 +69,6 @@ impl<'a> TryFrom<&'a [u8]> for CloseVaultInstructionData {
     }
 }
 ```
-</Codeblock>
 
 <ArticleSection name="Logic của instruction" id="instruction-logic" level="h2" />
 
@@ -90,7 +86,6 @@ Quá trình xác minh tuân theo các bước sau:
 
 Mã sẽ trông như thế này:
 
-<Codeblock lang="rust">
 ```rust
 pub struct CloseVault<'a> {
     pub accounts: CloseVaultAccounts<'a>,
@@ -133,6 +128,5 @@ impl<'a> CloseVault<'a> {
     }
 }
 ```
-</Codeblock>
 
 > Việc tái tạo thông điệp ngăn chặn các cuộc tấn công phát lại chữ ký, nơi các tác nhân độc hại thay thế các tài khoản người nhận khác nhau trong khi MEV-ing các chữ ký hợp lệ được ghi lại từ mempool.

--- a/src/app/content/challenges/pinocchio-quantum-vault/vi/pages/open.mdx
+++ b/src/app/content/challenges/pinocchio-quantum-vault/vi/pages/open.mdx
@@ -16,7 +16,6 @@ Instruction yêu cầu các tài khoản sau:
 
 Trong mã, nó sẽ trông như thế này:
 
-<Codeblock lang="rust">
 ```rust
 pub struct OpenVaultAccounts<'a> {
     pub payer: &'a AccountInfo,
@@ -35,7 +34,6 @@ impl<'a> TryFrom<&'a [AccountInfo]> for OpenVaultAccounts<'a> {
     }
 }
 ```
-</Codeblock>
 
 > Việc xác minh account được xử lý bởi CPI `CreateAccount`. Nếu các account không đáp ứng yêu cầu (signer, mutability, executability), instruction sẽ tự động thất bại.
 
@@ -49,7 +47,6 @@ Hai phần dữ liệu là cần thiết:
 
 Mã sẽ trông như thế này:
 
-<Codeblock lang="rust">
 ```rust
 pub struct OpenVaultInstructionData {
     pub hash: [u8; 32],
@@ -71,7 +68,6 @@ impl<'a> TryFrom<&'a [u8]> for OpenVaultInstructionData {
     }
 }
 ```
-</Codeblock>
 
 > Ở đây một lần nữa, các tham số không hợp lệ sẽ tự động sửa chữa: việc truyền một mã băm sai sẽ làm hỏng vault, việc truyền một bump sai sẽ làm thất bại việc dẫn xuất PDA.
 
@@ -83,7 +79,6 @@ Instruction này tạo ra một PDA trống được gán cho chương trình c�
 
 Mã sẽ trông như thế này:
 
-<Codeblock lang="rust">
 ```rust
 pub struct OpenVault<'a> {
     pub accounts: OpenVaultAccounts<'a>,
@@ -120,6 +115,5 @@ impl<'a> OpenVault<'a> {
     }
 }
 ```
-</Codeblock>
 
 > Instruction này chỉ tạo cấu trúc của vault. Các khoản tiền gửi được xử lý riêng biệt thông qua các lệnh chuyển khoản lamport đơn giản đến account vault.

--- a/src/app/content/challenges/pinocchio-quantum-vault/vi/pages/split.mdx
+++ b/src/app/content/challenges/pinocchio-quantum-vault/vi/pages/split.mdx
@@ -18,7 +18,6 @@ Account `refund` thường là một vault kháng lượng tử mới với cặ
 
 Mã sẽ trông như thế này:
 
-<Codeblock lang="rust">
 ```rust
 pub struct SplitVaultAccounts<'a> {
     pub vault: &'a AccountInfo,
@@ -38,7 +37,6 @@ impl<'a> TryFrom<&'a [AccountInfo]> for SplitVaultAccounts<'a> {
     }
 }
 ```
-</Codeblock>
 
 > Việc xác minh account được xử lý bởi runtime. Nếu các account không đáp ứng yêu cầu (khả năng có thể sửa đổi), instruction sẽ tự động thất bại.
 
@@ -51,7 +49,6 @@ Ba phần dữ liệu là cần thiết:
 
 Mã sẽ trông như thế này:
 
-<Codeblock lang="rust">
 ```rust
 pub struct SplitVaultInstructionData {
     pub signature: WinternitzSignature,
@@ -80,7 +77,6 @@ impl<'a> TryFrom<&'a [u8]> for SplitVaultInstructionData {
     }
 }
 ```
-</Codeblock>
 
 <ArticleSection name="Logic của instruction" id="instruction-logic" level="h2" />
 
@@ -98,7 +94,6 @@ Quá trình xác minh tuân theo các bước sau:
 
 Mã trông như thế này:
 
-<Codeblock lang="rust">
 ```rust
 pub struct SplitVault<'a> {
     pub accounts: SplitVaultAccounts<'a>,
@@ -149,6 +144,5 @@ impl<'a> SplitVault<'a> {
     }
 }
 ```
-</Codeblock>
 
 > Việc tái tạo thông điệp ngăn chặn các cuộc tấn công phát lại chữ ký, nơi các tác nhân độc hại thay thế các tài khoản người nhận khác nhau trong khi MEV-ing các chữ ký hợp lệ được ghi lại từ mempool.

--- a/src/app/content/challenges/pinocchio-secp256r1-vault/en/challenge.mdx
+++ b/src/app/content/challenges/pinocchio-secp256r1-vault/en/challenge.mdx
@@ -1,5 +1,4 @@
 import { ArticleSection } from "../../../../components/ArticleSection/ArticleSection";
-import { Codeblock } from "../../../../components/Codeblock/Codeblock";
 
 # The Secp256r1 Vault
 
@@ -17,34 +16,27 @@ In this challenge, we'll update the simple lamport vault that we built in the [P
 
 Before you begin, be sure Rust and Pinocchio are installed. Then in your terminal run:
 
-<Codeblock lang="terminal">
 ```bash
 # create workspace
 cargo new blueshift_secp256r1_vault --lib --edition 2021
 cd blueshift_secp256r1_vault
 ```
-</Codeblock>
 
 Add Pinocchio and the Pinocchio-compatible `Secp256r1` crate
-<Codeblock lang="terminal">
 ```bash
 cargo add pinocchio pinocchio-system pinocchio-secp256r1-instruction
 ```
-</Codeblock>
 
 Declare the crate types in `Cargo.toml` to generate deployment artifacts in `target/deploy`:
-<Codeblock lang="toml">
 ```toml
 [lib]
 crate-type = ["lib", "cdylib"]
 ```
-</Codeblock>
 
 <ArticleSection name="Template" id="template" level="h2" />
 
 Let's start with the basic program structure. We'll implement everything in `lib.rs` since this is a straightforward program. Here's the initial template with the core components we'll need:
 
-<Codeblock lang="rust">
 ```rust
 #![no_std]
 
@@ -76,7 +68,6 @@ fn process_instruction(
     }
 }
 ```
-</Codeblock>
 
 
 <ArticleSection name="Deposit" id="deposit" level="h2" />
@@ -92,7 +83,6 @@ Since with Secp256r1 signatures the owner of the actual wallet doesn't need to p
 
 So the account struct for `deposit` will look like this:
 
-<Codeblock lang="rust">
 ```rust
 pub struct DepositAccounts<'a> {
     pub payer: &'a AccountInfo,
@@ -125,7 +115,6 @@ impl<'a> TryFrom<&'a [AccountInfo]> for DepositAccounts<'a> {
     }
 }
 ```
-</Codeblock>
 
 Let's break down each account check:
 1. `payer`: Must be a signer since they need to authorize the transfer of lamports
@@ -140,7 +129,6 @@ Since part of the seed is in the `instruction_data` that we don't have access at
 
 Now let's implement the instruction data struct:
 
-<Codeblock lang="rust">
 ```rust
 #[repr(C, packed)]
 pub struct DepositInstructionData {
@@ -165,7 +153,6 @@ impl<'a> TryFrom<&'a [u8]> for DepositInstructionData {
     }
 }
 ```
-</Codeblock>
 
 We deserialize the instruction data into a `DepositInstructionData` struct that contains:
 - `pubkey`: The Secp256r1 public key of the user making the deposit
@@ -175,7 +162,6 @@ While unwrap is generally discouraged in production code, in this case, it is us
 
 Finally, let's implement the deposit instruction:
 
-<Codeblock lang="rust">
 ```rust
 pub struct Deposit<'a> {
     pub accounts: DepositAccounts<'a>,
@@ -222,7 +208,6 @@ impl<'a> Deposit<'a> {
     }
 }
 ```
-</Codeblock>
 
 As mentioned earlier, we need to verify that the vault PDA is derived from the correct seeds. In this Secp256r1-based vault, we use the `Secp256r1Pubkey` as part of the seeds instead of the traditional owner's public key. This is a crucial security measure that ensures only the holder of the corresponding Secp256r1 key can access the vault.
 
@@ -243,7 +228,6 @@ The withdraw instruction performs the following steps:
 
 First, let's define the account struct for withdraw:
 
-<Codeblock lang="rust">
 ```rust
 pub struct WithdrawAccounts<'a> {
     pub payer: &'a AccountInfo,
@@ -275,11 +259,9 @@ impl<'a> TryFrom<&'a [AccountInfo]> for WithdrawAccounts<'a> {
     }
 }
 ```
-</Codeblock>
 
 Now let's implement the instruction data struct:
 
-<Codeblock lang="rust">
 ```rust
 pub struct WithdrawInstructionData {
     pub bump: [u8;1]
@@ -295,13 +277,11 @@ impl<'a> TryFrom<&'a [u8]> for WithdrawInstructionData {
     }
 }
 ```
-</Codeblock>
 
 As you can see, for optimization purposese we passed the bump as instruction data to not have to derive it in the `process()` that is already "heavy" because of all the other checks needed.
 
 Finally, let's implement the `withdraw` instruction:
 
-<Codeblock lang="rust">
 ```rust
 pub struct Withdraw<'a> {
     pub accounts: WithdrawAccounts<'a>,
@@ -379,7 +359,6 @@ impl<'a> Withdraw<'a> {
     }
 }
 ```
-</Codeblock>
 
 The withdrawal process involves several security checks to ensure the transaction is legitimate. Let's break down how we verify the Secp256r1 signature and protect against potential attacks:
 
@@ -443,11 +422,9 @@ You can now test your program against our unit tests and claim your NFTs!
 
 Start by building your program using the following command in your terminal:
 
-<Codeblock lang="terminal">
 ```bash
 cargo build-sbf
 ```
-</Codeblock>
 
 This generated a `.so` file directly in your `target/deploy` folder. 
 

--- a/src/app/content/challenges/pinocchio-secp256r1-vault/fr/challenge.mdx
+++ b/src/app/content/challenges/pinocchio-secp256r1-vault/fr/challenge.mdx
@@ -1,5 +1,4 @@
 import { ArticleSection } from "../../../../components/ArticleSection/ArticleSection";
-import { Codeblock } from "../../../../components/Codeblock/Codeblock";
 
 ![Pinocchio Secp256r1 Vault Challenge](/graphics/challenge-banners/pinocchio-secp256r1-vault.png)
 
@@ -17,36 +16,29 @@ In this challenge, we'll update the simple lamport vault that we built in the [P
 
 Avant de commencer, assurez-vous que Rust et Pinocchio sont installés. Exécutez ensuite dans votre terminal :
 
-<Codeblock lang="terminal">
 ```bash
 # create workspace
 cargo new blueshift_secp256r1_vault --lib --edition 2021
 cd blueshift_secp256r1_vault
 ```
-</Codeblock>
 
 Ajoutez Pinocchio et la crate `Secp256r1` compatible avec Pinocchio
 
-<Codeblock lang="terminal">
 ```bash
 cargo add pinocchio pinocchio-system pinocchio-secp256r1-instruction
 ```
-</Codeblock>
 
 Déclarez les types de crate dans `Cargo.toml` pour générer les artefacts de déploiement dans `target/deploy` :
 
-<Codeblock lang="toml">
 ```toml
 [lib]
 crate-type = ["lib", "cdylib"]
 ```
-</Codeblock>
 
 <ArticleSection name="Modèle" id="template" level="h2" />
 
 Commençons par la structure de base du programme. Nous allons tout implémenter dans `lib.rs` puisqu'il s'agit d'un programme simple. Voici le modèle initial avec les composants clés dont nous aurons besoin :
 
-<Codeblock lang="rust">
 ```rust
 #![no_std]
 
@@ -78,7 +70,6 @@ fn process_instruction(
     }
 }
 ```
-</Codeblock>
 
 
 <ArticleSection name="Deposit" id="deposit" level="h2" />
@@ -94,7 +85,6 @@ La principale différence entre un vault normal et un vault Secp256r1 réside da
 
 La structure de compte pour `deposit` ressemblera donc à ceci :
 
-<Codeblock lang="rust">
 ```rust
 pub struct DepositAccounts<'a> {
     pub payer: &'a AccountInfo,
@@ -127,7 +117,6 @@ impl<'a> TryFrom<&'a [AccountInfo]> for DepositAccounts<'a> {
     }
 }
 ```
-</Codeblock>
 
 Détaillons chaque vérification de compte :
 1. `payer`: Il doit être un signataire car il doit autoriser le transfert de lamports
@@ -142,7 +131,6 @@ Puisqu'une partie des seeds se trouve dans `instruction_data` et que nous n'y av
 
 Implémentons maintenant la structure des données d'instruction :
 
-<Codeblock lang="rust">
 ```rust
 #[repr(C, packed)]
 pub struct DepositInstructionData {
@@ -167,7 +155,6 @@ impl<'a> TryFrom<&'a [u8]> for DepositInstructionData {
     }
 }
 ```
-</Codeblock>
 
 Nous désérialisons les données d'instruction dans une structure `DepositInstructionData` qui contient :
 - `pubkey`: La clé publique Secp256r1 de l'utilisateur effectuant le dépôt
@@ -177,7 +164,6 @@ Bien que *unwrap* soit généralement déconseillé en production, dans ce cas p
 
 Enfin, implémentons l'instruction `deposit` :
 
-<Codeblock lang="rust">
 ```rust
 pub struct Deposit<'a> {
     pub accounts: DepositAccounts<'a>,
@@ -224,7 +210,6 @@ impl<'a> Deposit<'a> {
     }
 }
 ```
-</Codeblock>
 
 Comme mentionné précédemment, nous devons vérifier que le PDA du vault est dérivé à partir des bonnes seeds. Dans ce vault basé sur Secp256r1, nous utilisons `Secp256r1Pubkey` comme seed à la place de la clé publique du propriétaire. Il s'agit d'une mesure de sécurité cruciale qui garantit que seul le détenteur de la clé Secp256r1 correspondante peut accéder au vault.
 
@@ -245,7 +230,6 @@ L'instruction `withdraw` effectue les étapes suivantes :
 
 Tout d'abord, définissons la structure de compte pour `withdraw` :
 
-<Codeblock lang="rust">
 ```rust
 pub struct WithdrawAccounts<'a> {
     pub payer: &'a AccountInfo,
@@ -277,11 +261,9 @@ impl<'a> TryFrom<&'a [AccountInfo]> for WithdrawAccounts<'a> {
     }
 }
 ```
-</Codeblock>
 
 Implémentons maintenant la structure des données d'instruction :
 
-<Codeblock lang="rust">
 ```rust
 pub struct WithdrawInstructionData {
     pub bump: [u8;1]
@@ -297,13 +279,11 @@ impl<'a> TryFrom<&'a [u8]> for WithdrawInstructionData {
     }
 }
 ```
-</Codeblock>
 
 Comme vous pouvez le constater, à des fins d'optimisation, nous avons transmis le bump en tant que données d'instruction afin de ne pas avoir à le dériver dans `process()` qui est déjà "lourd" en raison de toutes les autres vérifications nécessaires.
 
 Enfin, implémentons l'instruction `withdraw` :
 
-<Codeblock lang="rust">
 ```rust
 pub struct Withdraw<'a> {
     pub accounts: WithdrawAccounts<'a>,
@@ -381,7 +361,6 @@ impl<'a> Withdraw<'a> {
     }
 }
 ```
-</Codeblock>
 
 Le processus de retrait comprend plusieurs vérifications de sécurité afin de garantir la légitimité de la transaction. Voyons comment nous vérifions la signature Secp256r1 et comment nous nous protégeons contre de potentielles attaques :
 
@@ -445,11 +424,9 @@ Vous pouvez maintenant tester votre programme à l'aide de nos tests unitaires e
 
 Commencez par compiler votre programme en utilisant la commande suivante dans votre terminal :
 
-<Codeblock lang="terminal">
 ```bash
 cargo build-sbf
 ```
-</Codeblock>
 
 Cela générera un fichier `.so` directement dans votre dossier `target/deploy`. 
 

--- a/src/app/content/challenges/pinocchio-secp256r1-vault/vi/challenge.mdx
+++ b/src/app/content/challenges/pinocchio-secp256r1-vault/vi/challenge.mdx
@@ -1,5 +1,4 @@
 import { ArticleSection } from "../../../../components/ArticleSection/ArticleSection";
-import { Codeblock } from "../../../../components/Codeblock/Codeblock";
 
 # Secp256r1 Vault
 
@@ -17,35 +16,28 @@ Trong thử thách này, chúng ta sẽ cập nhật vault lamport đơn giản 
 
 Trước khi bắt đầu, hãy đảm bảo Rust và Pinocchio đã được cài đặt. Sau đó trong terminal của bạn chạy:
 
-<Codeblock lang="terminal">
 ```bash
 # create workspace
 cargo new blueshift_secp256r1_vault --lib --edition 2021
 cd blueshift_secp256r1_vault
 ```
-</Codeblock>
 
 Thêm crate Pinocchio và Pinocchio-compatible `Secp256r1`
-<Codeblock lang="terminal">
 ```bash
 cargo add pinocchio pinocchio-system pinocchio-secp256r1-instruction
 ```
-</Codeblock>
 
 Khai báo các loại crate trong `Cargo.toml` để tạo ra các artifact triển khai trong `target/deploy`:
 
-<Codeblock lang="toml">
 ```toml
 [lib]
 crate-type = ["lib", "cdylib"]
 ```
-</Codeblock>
 
 <ArticleSection name="Template" id="template" level="h2" />
 
 Hãy bắt đầu với cấu trúc chương trình cơ bản. Chúng ta sẽ triển khai mọi thứ trong `lib.rs` vì đây là một chương trình đơn giản. Đây là template ban đầu với các thành phần cốt lõi mà chúng ta sẽ cần:
 
-<Codeblock lang="rust">
 ```rust
 #![no_std]
 
@@ -77,7 +69,6 @@ fn process_instruction(
     }
 }
 ```
-</Codeblock>
 
 
 <ArticleSection name="Deposit" id="deposit" level="h2" />
@@ -93,7 +84,6 @@ Bởi vì với chữ ký Secp256r1, chủ sở hữu của ví thực tế khô
 
 Nên cấu trúc của tài khoản `deposit` sẽ trông như thế này: 
 
-<Codeblock lang="rust">
 ```rust
 pub struct DepositAccounts<'a> {
     pub payer: &'a AccountInfo,
@@ -126,7 +116,6 @@ impl<'a> TryFrom<&'a [AccountInfo]> for DepositAccounts<'a> {
     }
 }
 ```
-</Codeblock>
 
 Hãy phân tích từng mã kiểm tra tài khoản:
 1. `payer`: phải là signer vì họ cần ủy quyền cho chuyển tiền lamport.
@@ -141,7 +130,6 @@ Bởi vì phần seed nằm trong `instruction_data`, chúng ta sẽ không truy
 
 Bây giờ hãy triển khai struct dữ liệu cho instruction: 
 
-<Codeblock lang="rust">
 ```rust
 #[repr(C, packed)]
 pub struct DepositInstructionData {
@@ -166,7 +154,6 @@ impl<'a> TryFrom<&'a [u8]> for DepositInstructionData {
     }
 }
 ```
-</Codeblock>
 
 Chúng ta giải tuần tự hóa dữ liệu instruction vào một struct `DepositInstructionData` bao gồm:
 - `pubkey`: public key Secp256r1 của người dùng thực hiện deposit
@@ -176,7 +163,6 @@ Thông thường, unwrap không được khuyến khích sử dụng trong mã p
 
 Cuối cùng, hãy triển khai instruction deposit:
 
-<Codeblock lang="rust">
 ```rust
 pub struct Deposit<'a> {
     pub accounts: DepositAccounts<'a>,
@@ -223,7 +209,6 @@ impl<'a> Deposit<'a> {
     }
 }
 ```
-</Codeblock>
 
 Như đã nhắc đến trước đó, chúng ta cần xác minh rằng PDA của vault được derive từ các seed chính xác. Trong vault dựa trên Secp256r1 này, chúng ta sử dụng `Secp256r1Pubkey` làm một phần của các seed thay vì public key của chủ sở hữu truyền thống. Đây là một biện pháp bảo mật quan trọng đảm bảo chỉ người nắm giữ khóa Secp256r1 tương ứng mới có thể truy cập vào vault.
 
@@ -246,7 +231,6 @@ Widthdraw instruction thực hiện các bước sau:
 
 Đầu tiên, hãy định nghĩa struct tài khoản cho withdraw:
 
-<Codeblock lang="rust">
 ```rust
 pub struct WithdrawAccounts<'a> {
     pub payer: &'a AccountInfo,
@@ -278,11 +262,9 @@ impl<'a> TryFrom<&'a [AccountInfo]> for WithdrawAccounts<'a> {
     }
 }
 ```
-</Codeblock>
 
 Bây giờ hãy triển khai struct dữ liệu cho instruction: 
 
-<Codeblock lang="rust">
 ```rust
 pub struct WithdrawInstructionData {
     pub bump: [u8;1]
@@ -298,13 +280,11 @@ impl<'a> TryFrom<&'a [u8]> for WithdrawInstructionData {
     }
 }
 ```
-</Codeblock>
 
 Như bạn thấy, để tối ưu hóa chúng ta đã truyền bump vào trong dữ liệu instruction để không phải derive nó trong `process()` việc này khá "nặng" vì chúng ta phải kiểm tra nhiều thứ khác.
 
 Cuối cùng, hãy triển khai instruction `withdraw`:
 
-<Codeblock lang="rust">
 ```rust
 pub struct Withdraw<'a> {
     pub accounts: WithdrawAccounts<'a>,
@@ -382,7 +362,6 @@ impl<'a> Withdraw<'a> {
     }
 }
 ```
-</Codeblock>
 
 Quá trình withdraw đòi hỏi một vài bước kiểm tra bảo mật để đảm bảo rằng giao dịch là hợp lệ. Hãy xem chúng ta làm thế nào để xác minh chữ ký Secp256r1 và bảo vệ trước các cuộc tấn công tiềm năng:
 
@@ -445,11 +424,9 @@ Bạn có thể kiểm tra chương trình của mình với các bài kiểm tr
 
 Bắt đầu bằng cách build chương trình của bạn bằng lệnh sau trong terminal:
 
-<Codeblock lang="terminal">
 ```bash
 cargo build-sbf
 ```
-</Codeblock>
 
 Điều này tạo ra một file `.so` trực tiếp trong thư mục `target/deploy` của bạn.
 

--- a/src/app/content/challenges/pinocchio-vault/en/challenge.mdx
+++ b/src/app/content/challenges/pinocchio-vault/en/challenge.mdx
@@ -1,5 +1,4 @@
 import { ArticleSection } from "../../../../components/ArticleSection/ArticleSection";
-import { Codeblock } from "../../../../components/Codeblock/Codeblock";
 
 # The Vault
 
@@ -13,36 +12,29 @@ In this challenge, we'll build a simple lamport vault that demonstrates how to w
 
 Before you begin, be sure Rust and Pinocchio are installed. Then in your terminal run:
 
-<Codeblock lang="terminal">
 ```bash
 # create workspace
 cargo new blueshift_vault --lib --edition 2021
 cd blueshift_vault
 ```
-</Codeblock>
 
 Add Pinocchio:
 
-<Codeblock lang="terminal">
 ```bash
 cargo add pinocchio pinocchio-system
 ```
-</Codeblock>
 
 Declare the crate types in `Cargo.toml` to generate deployment artifacts in `target/deploy`:
 
-<Codeblock lang="toml">
 ```toml
 [lib]
 crate-type = ["lib", "cdylib"]
 ```
-</Codeblock>
 
 <ArticleSection name="Template" id="template" level="h2" />
 
 Let's start with the basic program structure. We'll implement everything in `lib.rs` since this is a straightforward program. Here's the initial template with the core components we'll need:
 
-<Codeblock lang="rust">
 ```rust
 #![no_std]
 
@@ -74,7 +66,6 @@ fn process_instruction(
     }
 }
 ```
-</Codeblock>
 
 
 <ArticleSection name="Deposit" id="deposit" level="h2" />
@@ -86,7 +77,6 @@ The deposit instruction performs the following steps:
 
 First, let's define the account struct for deposit:
 
-<Codeblock lang="rust">
 ```rust
 pub struct DepositAccounts<'a> {
     pub owner: &'a AccountInfo,
@@ -124,7 +114,6 @@ impl<'a> TryFrom<&'a [AccountInfo]> for DepositAccounts<'a> {
     }
 }
 ```
-</Codeblock>
 
 Let's break down each account check:
 1. `owner`: Must be a signer since they need to authorize the transaction
@@ -136,7 +125,6 @@ Let's break down each account check:
 
 Now let's implement the instruction data struct:
 
-<Codeblock lang="rust">
 ```rust
 pub struct DepositInstructionData {
     pub amount: u64,
@@ -161,13 +149,11 @@ impl<'a> TryFrom<&'a [u8]> for DepositInstructionData {
     }
 }
 ```
-</Codeblock>
 
 Here we just check that the amount is different from zero.
 
 Finally, let's implement the deposit instruction:
 
-<Codeblock lang="rust">
 ```rust
 pub struct Deposit<'a> {
     pub accounts: DepositAccounts<'a>,
@@ -203,7 +189,6 @@ impl<'a> Deposit<'a> {
     }
 }
 ```
-</Codeblock>
 
 <ArticleSection name="Withdraw" id="withdraw" level="h2" />
 
@@ -214,7 +199,6 @@ The withdraw instruction performs the following steps:
 
 First, let's define the account struct for withdraw:
 
-<Codeblock lang="rust">
 ```rust
 pub struct WithdrawAccounts<'a> {
     pub owner: &'a AccountInfo,
@@ -252,7 +236,6 @@ impl<'a> TryFrom<&'a [AccountInfo]> for WithdrawAccounts<'a> {
     }
 }
 ```
-</Codeblock>
 
 Let's break down each account check:
 1. `owner`: Must be a signer since they need to authorize the transaction
@@ -264,7 +247,6 @@ Let's break down each account check:
 
 Now let's implement the withdraw instruction:
 
-<Codeblock lang="rust">
 ```rust
 pub struct Withdraw<'a> {
     pub accounts: WithdrawAccounts<'a>,
@@ -304,7 +286,6 @@ impl<'a> Withdraw<'a> {
     }
 }
 ```
-</Codeblock>
 
 The security of this withdrawal is guaranteed by two factors:
 1. The vault's PDA is derived using the owner's public key, ensuring only the original depositor can withdraw
@@ -316,11 +297,9 @@ You can now test your program against our unit tests and claim your NFTs!
 
 Start by building your program using the following command in your terminal:
 
-<Codeblock lang="terminal">
 ```bash
 cargo build-sbf
 ```
-</Codeblock>
 
 This generated a `.so` file directly in your `target/deploy` folder. 
 

--- a/src/app/content/challenges/pinocchio-vault/fr/challenge.mdx
+++ b/src/app/content/challenges/pinocchio-vault/fr/challenge.mdx
@@ -1,5 +1,4 @@
 import { ArticleSection } from "../../../../components/ArticleSection/ArticleSection";
-import { Codeblock } from "../../../../components/Codeblock/Codeblock";
 
 ![Pinocchio Vault Challenge](/graphics/challenge-banners/pinocchio-vault.png)
 
@@ -13,36 +12,29 @@ Dans ce challenge, nous allons créer un vault à lamport simple qui montre comm
 
 Avant de commencer, assurez-vous que Rust et Pinocchio sont installés. Exécutez ensuite dans votre terminal :
 
-<Codeblock lang="terminal">
 ```bash
 # create workspace
 cargo new blueshift_vault --lib --edition 2021
 cd blueshift_vault
 ```
-</Codeblock>
 
 Ajoutez Pinocchio:
 
-<Codeblock lang="terminal">
 ```bash
 cargo add pinocchio pinocchio-system
 ```
-</Codeblock>
 
 Déclarez les types de crate dans `Cargo.toml` pour générer les artefacts de déploiement dans `target/deploy` :
 
-<Codeblock lang="toml">
 ```toml
 [lib]
 crate-type = ["lib", "cdylib"]
 ```
-</Codeblock>
 
 <ArticleSection name="Modèle" id="template" level="h2" />
 
 Commençons par la structure de base du programme. Nous allons tout implémenter dans `lib.rs` puisqu'il s'agit d'un programme simple. Voici le modèle initial avec les composants clés dont nous aurons besoin :
 
-<Codeblock lang="rust">
 ```rust
 #![no_std]
 
@@ -74,7 +66,6 @@ fn process_instruction(
     }
 }
 ```
-</Codeblock>
 
 
 <ArticleSection name="Deposit" id="deposit" level="h2" />
@@ -86,7 +77,6 @@ L'instruction `deposit` effectue les étapes suivantes :
 
 Tout d'abord, définissons la structure de compte pour `deposit` :
 
-<Codeblock lang="rust">
 ```rust
 pub struct DepositAccounts<'a> {
     pub owner: &'a AccountInfo,
@@ -124,7 +114,6 @@ impl<'a> TryFrom<&'a [AccountInfo]> for DepositAccounts<'a> {
     }
 }
 ```
-</Codeblock>
 
 Détaillons chaque vérification de compte :
 1. `owner`: Doit être signataire car il doit autoriser la transaction
@@ -136,7 +125,6 @@ Détaillons chaque vérification de compte :
 
 Implémentons maintenant la structure des données d'instruction :
 
-<Codeblock lang="rust">
 ```rust
 pub struct DepositInstructionData {
     pub amount: u64,
@@ -161,13 +149,11 @@ impl<'a> TryFrom<&'a [u8]> for DepositInstructionData {
     }
 }
 ```
-</Codeblock>
 
 Ici, nous vérifions uniquement que le montant est différent de zéro.
 
 Enfin, implémentons l'instruction `deposit` :
 
-<Codeblock lang="rust">
 ```rust
 pub struct Deposit<'a> {
     pub accounts: DepositAccounts<'a>,
@@ -203,7 +189,6 @@ impl<'a> Deposit<'a> {
     }
 }
 ```
-</Codeblock>
 
 <ArticleSection name="Withdraw" id="withdraw" level="h2" />
 
@@ -214,7 +199,6 @@ L'instruction `withdraw` effectue les étapes suivantes :
 
 Tout d'abord, définissons la structure de compte pour `withdraw` :
 
-<Codeblock lang="rust">
 ```rust
 pub struct WithdrawAccounts<'a> {
     pub owner: &'a AccountInfo,
@@ -252,7 +236,6 @@ impl<'a> TryFrom<&'a [AccountInfo]> for WithdrawAccounts<'a> {
     }
 }
 ```
-</Codeblock>
 
 Détaillons chaque vérification de compte :
 1. `owner`: Doit être signataire car il doit autoriser la transaction
@@ -264,7 +247,6 @@ Détaillons chaque vérification de compte :
 
 Implémentons maintenant l'instruction `withdraw` :
 
-<Codeblock lang="rust">
 ```rust
 pub struct Withdraw<'a> {
     pub accounts: WithdrawAccounts<'a>,
@@ -304,7 +286,6 @@ impl<'a> Withdraw<'a> {
     }
 }
 ```
-</Codeblock>
 
 La sécurité de ce retrait est garantie par deux mesures :
 1. Le PDA du vault est dérivé à partir de la clé publique du propriétaire, garantissant ainsi que seul le déposant initial peut effectuer des retraits
@@ -316,11 +297,9 @@ Vous pouvez maintenant tester votre programme à l'aide de nos tests unitaires e
 
 Commencez par compiler votre programme en utilisant la commande suivante dans votre terminal :
 
-<Codeblock lang="terminal">
 ```bash
 cargo build-sbf
 ```
-</Codeblock>
 
 Cela générera un fichier `.so` directement dans votre dossier `target/deploy`. 
 

--- a/src/app/content/challenges/pinocchio-vault/vi/challenge.mdx
+++ b/src/app/content/challenges/pinocchio-vault/vi/challenge.mdx
@@ -1,5 +1,4 @@
 import { ArticleSection } from "../../../../components/ArticleSection/ArticleSection";
-import { Codeblock } from "../../../../components/Codeblock/Codeblock";
 
 # Vault
 
@@ -13,36 +12,29 @@ Trong thử thách này, chúng ta sẽ xây dựng một vault lamport đơn gi
 
 Trước khi bắt đầu, hãy đảm bảo Rust và Pinocchio đã được cài đặt. Sau đó trong terminal của bạn chạy:
 
-<Codeblock lang="terminal">
 ```bash
 # tạo workspace
 cargo new blueshift_vault --lib --edition 2021
 cd blueshift_vault
 ```
-</Codeblock>
 
 Thêm Pinocchio:
 
-<Codeblock lang="terminal">
 ```bash
 cargo add pinocchio pinocchio-system
 ```
-</Codeblock>
 
 Khai báo các loại crate trong `Cargo.toml` để tạo ra các artifact triển khai trong `target/deploy`:
 
-<Codeblock lang="toml">
 ```toml
 [lib]
 crate-type = ["lib", "cdylib"]
 ```
-</Codeblock>
 
 <ArticleSection name="Template" id="template" level="h2" />
 
 Hãy bắt đầu với cấu trúc chương trình cơ bản. Chúng ta sẽ triển khai mọi thứ trong `lib.rs` vì đây là một chương trình đơn giản. Đây là template ban đầu với các thành phần cốt lõi mà chúng ta sẽ cần:
 
-<Codeblock lang="rust">
 ```rust
 #![no_std]
 
@@ -74,7 +66,6 @@ fn process_instruction(
     }
 }
 ```
-</Codeblock>
 
 
 <ArticleSection name="Deposit" id="deposit" level="h2" />
@@ -86,7 +77,6 @@ Instruction deposit thực hiện các bước sau:
 
 Đầu tiên, hãy định nghĩa struct tài khoản cho deposit:
 
-<Codeblock lang="rust">
 ```rust
 pub struct DepositAccounts<'a> {
     pub owner: &'a AccountInfo,
@@ -124,7 +114,6 @@ impl<'a> TryFrom<&'a [AccountInfo]> for DepositAccounts<'a> {
     }
 }
 ```
-</Codeblock>
 
 Hãy phân tích từng kiểm tra tài khoản:
 1. `owner`: Phải là signer vì họ cần ủy quyền cho giao dịch
@@ -136,7 +125,6 @@ Hãy phân tích từng kiểm tra tài khoản:
 
 Bây giờ hãy triển khai struct dữ liệu instruction:
 
-<Codeblock lang="rust">
 ```rust
 pub struct DepositInstructionData {
     pub amount: u64,
@@ -161,13 +149,11 @@ impl<'a> TryFrom<&'a [u8]> for DepositInstructionData {
     }
 }
 ```
-</Codeblock>
 
 Ở đây chúng ta chỉ kiểm tra rằng số tiền khác zero.
 
 Cuối cùng, hãy triển khai instruction deposit:
 
-<Codeblock lang="rust">
 ```rust
 pub struct Deposit<'a> {
     pub accounts: DepositAccounts<'a>,
@@ -203,7 +189,6 @@ impl<'a> Deposit<'a> {
     }
 }
 ```
-</Codeblock>
 
 <ArticleSection name="Withdraw" id="withdraw" level="h2" />
 
@@ -214,7 +199,6 @@ Instruction withdraw thực hiện các bước sau:
 
 Đầu tiên, hãy định nghĩa struct tài khoản cho withdraw:
 
-<Codeblock lang="rust">
 ```rust
 pub struct WithdrawAccounts<'a> {
     pub owner: &'a AccountInfo,
@@ -252,7 +236,6 @@ impl<'a> TryFrom<&'a [AccountInfo]> for WithdrawAccounts<'a> {
     }
 }
 ```
-</Codeblock>
 
 Hãy phân tích từng kiểm tra tài khoản:
 1. `owner`: Phải là signer vì họ cần ủy quyền cho giao dịch
@@ -264,7 +247,6 @@ Hãy phân tích từng kiểm tra tài khoản:
 
 Bây giờ hãy triển khai instruction withdraw:
 
-<Codeblock lang="rust">
 ```rust
 pub struct Withdraw<'a> {
     pub accounts: WithdrawAccounts<'a>,
@@ -304,7 +286,6 @@ impl<'a> Withdraw<'a> {
     }
 }
 ```
-</Codeblock>
 
 Tính bảo mật của việc rút tiền này được đảm bảo bởi hai yếu tố:
 1. PDA của vault được tạo bằng cách sử dụng public key của owner, đảm bảo chỉ người gửi tiền ban đầu mới có thể rút
@@ -316,11 +297,9 @@ Bây giờ bạn có thể kiểm tra chương trình của mình với các uni
 
 Bắt đầu bằng cách build chương trình của bạn bằng lệnh sau trong terminal:
 
-<Codeblock lang="terminal">
 ```bash
 cargo build-sbf
 ```
-</Codeblock>
 
 Điều này tạo ra một file `.so` trực tiếp trong thư mục `target/deploy` của bạn.
 

--- a/src/app/content/challenges/typescript-mint-an-spl-token/en/challenge.mdx
+++ b/src/app/content/challenges/typescript-mint-an-spl-token/en/challenge.mdx
@@ -1,5 +1,4 @@
 import { ArticleSection } from "../../../../components/ArticleSection/ArticleSection";
-import { Codeblock } from "../../../../components/Codeblock/Codeblock";
 
 # Mint an SPL Token
 

--- a/src/app/content/courses/anchor-for-dummies/anchor-101/en.mdx
+++ b/src/app/content/courses/anchor-for-dummies/anchor-101/en.mdx
@@ -1,5 +1,4 @@
 import { ArticleSection } from "../../../../components/ArticleSection/ArticleSection";
-import { Codeblock } from "../../../../components/Codeblock/Codeblock";
 
 # Anchor 101
 

--- a/src/app/content/courses/anchor-for-dummies/anchor-101/fr.mdx
+++ b/src/app/content/courses/anchor-for-dummies/anchor-101/fr.mdx
@@ -1,5 +1,4 @@
 import { ArticleSection } from "../../../../components/ArticleSection/ArticleSection";
-import { Codeblock } from "../../../../components/Codeblock/Codeblock";
 
 # Anchor 101
 

--- a/src/app/content/courses/anchor-for-dummies/anchor-101/vi.mdx
+++ b/src/app/content/courses/anchor-for-dummies/anchor-101/vi.mdx
@@ -1,5 +1,4 @@
 import { ArticleSection } from "../../../../components/ArticleSection/ArticleSection";
-import { Codeblock } from "../../../../components/Codeblock/Codeblock";
 
 # Anchor 101
 

--- a/src/app/content/courses/anchor-for-dummies/anchor-101/zh-CN.mdx
+++ b/src/app/content/courses/anchor-for-dummies/anchor-101/zh-CN.mdx
@@ -1,5 +1,4 @@
 import { ArticleSection } from "../../../../components/ArticleSection/ArticleSection";
-import { Codeblock } from "../../../../components/Codeblock/Codeblock";
 
 # Anchor 101
 

--- a/src/app/content/courses/anchor-for-dummies/testing-your-program/en.mdx
+++ b/src/app/content/courses/anchor-for-dummies/testing-your-program/en.mdx
@@ -22,11 +22,9 @@ TypeScript tests offer key advantages:
 
 Run tests with:
 
-<Codeblock lang="terminal">
 ```bash
 anchor test
 ```
-</Codeblock>
 
 > Run on localnet by setting the cluster to localnet in your configuration. This spins up a local validator and adds 1,000 SOL to the provider wallet. If you need additional accounts with data inside of them, look at running a [Local Validator](/en/courses/anchor-for-dummies/testing-your-program#running-a-local-validator)
 
@@ -44,19 +42,15 @@ We covered Mollusk testing thoroughly [here](/en/courses/testing-with-mollusk).
 
 Create a new Anchor program with Mollusk:
 
-<Codeblock lang="terminal">
 ```bash
 anchor init <name-of-the-project> --test-template mollusk
 ```
-</Codeblock>
 
 Run tests using:
 
-<Codeblock lang="terminal">
 ```bash
 anchor test
 ```
-</Codeblock>
 
 <ArticleSection name="LiteSVM Tests" id="litesvm-tests" level="h2" />
 
@@ -76,15 +70,12 @@ You can set up your Anchor provider and use the client-side setup we saw [previo
 
 Installe the `anchor-litesvm` package.
 
-<Codeblock lang="terminal">
 ```bash
 npm install git:https://github.com/LiteSVM/anchor-litesvm
 ```
-</Codeblock>
 
 Then change the default Anchor provider to `LiteSVMProvider` like this:
 
-<Codeblock lang="ts">
 ```ts
 import { fromWorkspace, LiteSVMProvider } from "anchor-litesvm";
 
@@ -96,7 +87,6 @@ test("anchor", async () => {
     // program.methods..
 })
 ```
-</Codeblock>
 
 <ArticleSection name="Running a Local Validator" id="running-a-local-validator" level="h2" />
 
@@ -155,11 +145,9 @@ Surfnet serves as a drop-in replacement for solana-test-validator that enables d
 
 To use it, just install surfpool using the official [Installation Page](https://docs.surfpool.run/install) and then run:
 
-<Codeblock lang="terminal">
 ```bash
 surfpool start
 ```
-</Codeblock>
 
 You can now connect to Surfnet by targeting the local validator:
 

--- a/src/app/content/courses/create-your-sdk-with-codama/introduction/en.mdx
+++ b/src/app/content/courses/create-your-sdk-with-codama/introduction/en.mdx
@@ -1,5 +1,4 @@
 import { ArticleSection } from "../../../../components/ArticleSection/ArticleSection";
-import { Codeblock } from "../../../../components/Codeblock/Codeblock";
 
 # Codama 101
 

--- a/src/app/content/courses/create-your-sdk-with-codama/introduction/vi.mdx
+++ b/src/app/content/courses/create-your-sdk-with-codama/introduction/vi.mdx
@@ -1,5 +1,4 @@
 import { ArticleSection } from "../../../../components/ArticleSection/ArticleSection";
-import { Codeblock } from "../../../../components/Codeblock/Codeblock";
 
 # Codama
 

--- a/src/app/content/courses/instruction-introspection/introduction/en.mdx
+++ b/src/app/content/courses/instruction-introspection/introduction/en.mdx
@@ -1,5 +1,4 @@
 import { ArticleSection } from "../../../../components/ArticleSection/ArticleSection";
-import { Codeblock } from "../../../../components/Codeblock/Codeblock";
 
 # Instruction Introspection
 

--- a/src/app/content/courses/instruction-introspection/introduction/fr.mdx
+++ b/src/app/content/courses/instruction-introspection/introduction/fr.mdx
@@ -1,5 +1,4 @@
 import { ArticleSection } from "../../../../components/ArticleSection/ArticleSection";
-import { Codeblock } from "../../../../components/Codeblock/Codeblock";
 
 # Introspection des Instructions
 

--- a/src/app/content/courses/instruction-introspection/introduction/vi.mdx
+++ b/src/app/content/courses/instruction-introspection/introduction/vi.mdx
@@ -1,5 +1,4 @@
 import { ArticleSection } from "../../../../components/ArticleSection/ArticleSection";
-import { Codeblock } from "../../../../components/Codeblock/Codeblock";
 
 # Instruction Introspection
 

--- a/src/app/content/courses/instruction-introspection/introduction/zh-CN.mdx
+++ b/src/app/content/courses/instruction-introspection/introduction/zh-CN.mdx
@@ -1,5 +1,4 @@
 import { ArticleSection } from "../../../../components/ArticleSection/ArticleSection";
-import { Codeblock } from "../../../../components/Codeblock/Codeblock";
 
 # 指令内省
 

--- a/src/app/content/courses/instruction-introspection/introspection-with-anchor/en.mdx
+++ b/src/app/content/courses/instruction-introspection/introspection-with-anchor/en.mdx
@@ -1,5 +1,4 @@
 import { ArticleSection } from "../../../../components/ArticleSection/ArticleSection";
-import { Codeblock } from "../../../../components/Codeblock/Codeblock";
 
 # Instruction Introspection with Anchor
 

--- a/src/app/content/courses/instruction-introspection/introspection-with-anchor/fr.mdx
+++ b/src/app/content/courses/instruction-introspection/introspection-with-anchor/fr.mdx
@@ -1,5 +1,4 @@
 import { ArticleSection } from "../../../../components/ArticleSection/ArticleSection";
-import { Codeblock } from "../../../../components/Codeblock/Codeblock";
 
 # Introspection des Instructions avec Anchor
 

--- a/src/app/content/courses/instruction-introspection/introspection-with-anchor/vi.mdx
+++ b/src/app/content/courses/instruction-introspection/introspection-with-anchor/vi.mdx
@@ -1,5 +1,4 @@
 import { ArticleSection } from "../../../../components/ArticleSection/ArticleSection";
-import { Codeblock } from "../../../../components/Codeblock/Codeblock";
 
 # Instruction Introspection với Anchor
 

--- a/src/app/content/courses/instruction-introspection/introspection-with-anchor/zh-CN.mdx
+++ b/src/app/content/courses/instruction-introspection/introspection-with-anchor/zh-CN.mdx
@@ -1,5 +1,4 @@
 import { ArticleSection } from "../../../../components/ArticleSection/ArticleSection";
-import { Codeblock } from "../../../../components/Codeblock/Codeblock";
 
 # 使用 Anchor 进行指令内省
 

--- a/src/app/content/courses/instruction-introspection/introspection-with-pinocchio/en.mdx
+++ b/src/app/content/courses/instruction-introspection/introspection-with-pinocchio/en.mdx
@@ -1,5 +1,4 @@
 import { ArticleSection } from "../../../../components/ArticleSection/ArticleSection";
-import { Codeblock } from "../../../../components/Codeblock/Codeblock";
 
 # Instruction Introspection with Pinocchio
 

--- a/src/app/content/courses/instruction-introspection/introspection-with-pinocchio/fr.mdx
+++ b/src/app/content/courses/instruction-introspection/introspection-with-pinocchio/fr.mdx
@@ -1,5 +1,4 @@
 import { ArticleSection } from "../../../../components/ArticleSection/ArticleSection";
-import { Codeblock } from "../../../../components/Codeblock/Codeblock";
 
 # Introspection des Instructions avec Pinocchio
 

--- a/src/app/content/courses/instruction-introspection/introspection-with-pinocchio/vi.mdx
+++ b/src/app/content/courses/instruction-introspection/introspection-with-pinocchio/vi.mdx
@@ -1,5 +1,4 @@
 import { ArticleSection } from "../../../../components/ArticleSection/ArticleSection";
-import { Codeblock } from "../../../../components/Codeblock/Codeblock";
 
 # Instruction Introspection với Pinocchio
 

--- a/src/app/content/courses/instruction-introspection/introspection-with-pinocchio/zh-CN.mdx
+++ b/src/app/content/courses/instruction-introspection/introspection-with-pinocchio/zh-CN.mdx
@@ -1,5 +1,4 @@
 import { ArticleSection } from "../../../../components/ArticleSection/ArticleSection";
-import { Codeblock } from "../../../../components/Codeblock/Codeblock";
 
 # 使用 Pinocchio 进行指令内省
 

--- a/src/app/content/courses/introduction-to-assembly/assembly-101/en.mdx
+++ b/src/app/content/courses/introduction-to-assembly/assembly-101/en.mdx
@@ -1,5 +1,4 @@
 import { ArticleSection } from "../../../../components/ArticleSection/ArticleSection";
-import { Codeblock } from "../../../../components/Codeblock/Codeblock";
 
 # sBPF Assembly 101
 

--- a/src/app/content/courses/introduction-to-low-level-solana/entrypoint/en.mdx
+++ b/src/app/content/courses/introduction-to-low-level-solana/entrypoint/en.mdx
@@ -1,5 +1,4 @@
 import { ArticleSection } from "../../../../components/ArticleSection/ArticleSection";
-import { Codeblock } from "../../../../components/Codeblock/Codeblock";
 
 # The Entrypoint 
 

--- a/src/app/content/courses/introduction-to-low-level-solana/entrypoint/vi.mdx
+++ b/src/app/content/courses/introduction-to-low-level-solana/entrypoint/vi.mdx
@@ -1,5 +1,4 @@
 import { ArticleSection } from "../../../../components/ArticleSection/ArticleSection";
-import { Codeblock } from "../../../../components/Codeblock/Codeblock";
 
 # The Entrypoint 
 

--- a/src/app/content/courses/introduction-to-low-level-solana/entrypoint/zh-CN.mdx
+++ b/src/app/content/courses/introduction-to-low-level-solana/entrypoint/zh-CN.mdx
@@ -1,5 +1,4 @@
 import { ArticleSection } from "../../../../components/ArticleSection/ArticleSection";
-import { Codeblock } from "../../../../components/Codeblock/Codeblock";
 
 # 入口点
 

--- a/src/app/content/courses/introduction-to-low-level-solana/low-level-101/en.mdx
+++ b/src/app/content/courses/introduction-to-low-level-solana/low-level-101/en.mdx
@@ -1,5 +1,4 @@
 import { ArticleSection } from "../../../../components/ArticleSection/ArticleSection";
-import { Codeblock } from "../../../../components/Codeblock/Codeblock";
 
 # Low-level 101
 

--- a/src/app/content/courses/introduction-to-low-level-solana/low-level-101/vi.mdx
+++ b/src/app/content/courses/introduction-to-low-level-solana/low-level-101/vi.mdx
@@ -1,5 +1,4 @@
 import { ArticleSection } from "../../../../components/ArticleSection/ArticleSection";
-import { Codeblock } from "../../../../components/Codeblock/Codeblock";
 
 # Low-level 101
 

--- a/src/app/content/courses/introduction-to-low-level-solana/low-level-101/zh-CN.mdx
+++ b/src/app/content/courses/introduction-to-low-level-solana/low-level-101/zh-CN.mdx
@@ -1,5 +1,4 @@
 import { ArticleSection } from "../../../../components/ArticleSection/ArticleSection";
-import { Codeblock } from "../../../../components/Codeblock/Codeblock";
 
 # 低级编程 101
 

--- a/src/app/content/courses/introduction-to-pinocchio/performance/en.mdx
+++ b/src/app/content/courses/introduction-to-pinocchio/performance/en.mdx
@@ -1,5 +1,4 @@
 import { ArticleSection } from "../../../../components/ArticleSection/ArticleSection";
-import { Codeblock } from "../../../../components/Codeblock/Codeblock";
 
 # Performance
 

--- a/src/app/content/courses/introduction-to-pinocchio/performance/fr.mdx
+++ b/src/app/content/courses/introduction-to-pinocchio/performance/fr.mdx
@@ -1,5 +1,4 @@
 import { ArticleSection } from "../../../../components/ArticleSection/ArticleSection";
-import { Codeblock } from "../../../../components/Codeblock/Codeblock";
 
 # Performance
 

--- a/src/app/content/courses/introduction-to-pinocchio/performance/vi.mdx
+++ b/src/app/content/courses/introduction-to-pinocchio/performance/vi.mdx
@@ -1,5 +1,4 @@
 import { ArticleSection } from "../../../../components/ArticleSection/ArticleSection";
-import { Codeblock } from "../../../../components/Codeblock/Codeblock";
 
 # Hiệu suất
 

--- a/src/app/content/courses/introduction-to-pinocchio/performance/zh-CN.mdx
+++ b/src/app/content/courses/introduction-to-pinocchio/performance/zh-CN.mdx
@@ -1,5 +1,4 @@
 import { ArticleSection } from "../../../../components/ArticleSection/ArticleSection";
-import { Codeblock } from "../../../../components/Codeblock/Codeblock";
 
 # 性能
 

--- a/src/app/content/courses/introduction-to-pinocchio/pinocchio-101/en.mdx
+++ b/src/app/content/courses/introduction-to-pinocchio/pinocchio-101/en.mdx
@@ -1,5 +1,4 @@
 import { ArticleSection } from "../../../../components/ArticleSection/ArticleSection";
-import { Codeblock } from "../../../../components/Codeblock/Codeblock";
 
 # Pinocchio 101
 

--- a/src/app/content/courses/introduction-to-pinocchio/pinocchio-101/fr.mdx
+++ b/src/app/content/courses/introduction-to-pinocchio/pinocchio-101/fr.mdx
@@ -1,5 +1,4 @@
 import { ArticleSection } from "../../../../components/ArticleSection/ArticleSection";
-import { Codeblock } from "../../../../components/Codeblock/Codeblock";
 
 # Pinocchio 101
 

--- a/src/app/content/courses/introduction-to-pinocchio/pinocchio-101/vi.mdx
+++ b/src/app/content/courses/introduction-to-pinocchio/pinocchio-101/vi.mdx
@@ -1,5 +1,4 @@
 import { ArticleSection } from "../../../../components/ArticleSection/ArticleSection";
-import { Codeblock } from "../../../../components/Codeblock/Codeblock";
 
 # Pinocchio 101
 

--- a/src/app/content/courses/introduction-to-pinocchio/pinocchio-101/zh-CN.mdx
+++ b/src/app/content/courses/introduction-to-pinocchio/pinocchio-101/zh-CN.mdx
@@ -1,5 +1,4 @@
 import { ArticleSection } from "../../../../components/ArticleSection/ArticleSection";
-import { Codeblock } from "../../../../components/Codeblock/Codeblock";
 
 # Pinocchio 101
 

--- a/src/app/content/courses/introduction-to-pinocchio/pinocchio-accounts/en.mdx
+++ b/src/app/content/courses/introduction-to-pinocchio/pinocchio-accounts/en.mdx
@@ -1,5 +1,4 @@
 import { ArticleSection } from "../../../../components/ArticleSection/ArticleSection";
-import { Codeblock } from "../../../../components/Codeblock/Codeblock";
 
 # Accounts
 
@@ -89,7 +88,6 @@ Now let's see how we apply this to our account security checks:
 
 As we saw in the previous examples, `SystemAccount` and `SignerAccount` checks are straightforward and don't require any additional validation, so we're going to add the following to our `helper.rs`:
 
-<Codeblock lang="rust">
 ```rust
 pub trait AccountCheck {
     fn check(account: &AccountInfo) -> Result<(), ProgramError>;
@@ -118,7 +116,6 @@ impl AccountCheck for SystemAccount {
     }
 }
 ```
-</Codeblock>
 
 Here we simply check if the account is a signer or if it's owned by the system program. Notice how both structs provide the same check method, giving us that common interface we talked about.
 
@@ -126,7 +123,6 @@ Here we simply check if the account is a signer or if it's owned by the system p
 
 Now things get more interesting. We start with the usual `AccountCheck` trait, but we also add other specific traits to provide additional helpers that resemble Anchor macros like `init` and `init_if_needed`.
 
-<Codeblock lang="rust">
 ```rust
 pub struct MintAccount;
 
@@ -144,11 +140,9 @@ impl AccountCheck for MintAccount {
     }
 }
 ```
-</Codeblock>
 
 For the `init` and `init_if_needed` functionality, we create another trait called `MintInit` that we use specifically for this purpose because of the unique fields required. We then use `CreateAccount` and `InitializeMint2` CPIs to initialize the `Mint` account:
 
-<Codeblock lang="rust">
 ```rust
 pub trait MintInit {
     fn init(account: &AccountInfo, payer: &AccountInfo, decimals: u8, mint_authority: &[u8; 32], freeze_authority: Option<&[u8; 32]>) -> ProgramResult;
@@ -185,12 +179,10 @@ impl MintInit for MintAccount {
     }
 }
 ```
-</Codeblock>
 
 
 We then do exactly the same for the `TokenAccount`:
 
-<Codeblock lang="rust">
 ```rust
 pub struct TokenAccount;
 
@@ -243,7 +235,6 @@ impl AccountInit for TokenAccount {
     }
 }
 ```
-</Codeblock>
 
 ### Token2022
 
@@ -257,7 +248,6 @@ For Token2022, we can distinguish between a `Mint` and a `TokenAccount` in two w
 
 This leads to modified validation checks:
 
-<Codeblock lang="rust">
 ```rust
 // TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb
 pub const TOKEN_2022_PROGRAM_ID: [u8; 32] = [
@@ -373,13 +363,11 @@ impl AccountInit for TokenAccount2022Account {
     }
 }
 ```
-</Codeblock>
 
 ### Token Interface
 
 Since we want to make it easy to work with both Token2022 and Legacy Token Programs without having to discriminate between them, we created a helper that follows the same basic principle:
 
-<Codeblock lang="rust">
 ```rust
 pub struct MintInterface;
 
@@ -441,13 +429,11 @@ impl AccountCheck for TokenAccountInterface {
     }
 }
 ```
-</Codeblock>
 
 ### Associated Token Account
 
 We can create some checks for the Associated Token Program. These are very similar to the normal Token Program checks, but they include an additional derivation check to ensure the account is derived correctly.
 
-<Codeblock lang="rust">
 ```rust
 pub struct AssociatedTokenAccount;
 
@@ -494,7 +480,6 @@ impl AssociatedTokenAccountInit for AssociatedTokenAccount {
     }
 }
 ```
-</Codeblock>
 
 <ArticleSection name="Program Accounts" id="program-accounts" level="h2" />
 
@@ -504,7 +489,6 @@ You might notice something interesting in our `close` implementation: we resize 
 
 A reinitialization attack occurs when an attacker attempts to reuse a closed account by reinitializing it with malicious data. By setting the first byte to 255 and shrinking the account to nearly zero size, we make it impossible for the account to be mistaken for any valid account type in the future. This is a common security pattern in Solana programs.
 
-<Codeblock lang="rust">
   ```rust
   pub struct ProgramAccount;
 
@@ -575,7 +559,6 @@ A reinitialization attack occurs when an attacker attempts to reuse a closed acc
       }
   }
   ```
-</Codeblock>
 
 ### Optimizing Account Data Access
 

--- a/src/app/content/courses/introduction-to-pinocchio/pinocchio-accounts/fr.mdx
+++ b/src/app/content/courses/introduction-to-pinocchio/pinocchio-accounts/fr.mdx
@@ -1,5 +1,4 @@
 import { ArticleSection } from "../../../../components/ArticleSection/ArticleSection";
-import { Codeblock } from "../../../../components/Codeblock/Codeblock";
 
 # Comptes
 
@@ -89,7 +88,6 @@ Voyons maintenant comment appliquer cela à nos contrôles de sécurité des com
 
 Comme nous l'avons vu dans les exemples précédents, les vérifications `SystemAccount` et `SignerAccount` sont simples et ne nécessitent aucune validation supplémentaire. Nous allons donc ajouter ce qui suit à notre fichier `helper.rs` :
 
-<Codeblock lang="rust">
 ```rust
 pub trait AccountCheck {
     fn check(account: &AccountInfo) -> Result<(), ProgramError>;
@@ -118,7 +116,6 @@ impl AccountCheck for SystemAccount {
     }
 }
 ```
-</Codeblock>
 
 Ici, nous vérifions simplement si le compte est un signataire ou s'il appartient au Programme Système. Remarquez que les deux structures fournissent la même méthode de vérification ce qui nous donne l'interface commune dont nous avons parlé.
 
@@ -126,7 +123,6 @@ Ici, nous vérifions simplement si le compte est un signataire ou s'il appartien
 
 Les choses deviennent maintenant plus intéressantes. Nous commençons par le trait habituel `AccountCheck` mais nous ajoutons également d'autres traits spécifiques afin de fournir des fonctions d'aide supplémentaires qui ressemblent aux macros Anchor telles que `init` et `init_if_needed`.
 
-<Codeblock lang="rust">
 ```rust
 pub struct MintAccount;
 
@@ -144,11 +140,9 @@ impl AccountCheck for MintAccount {
     }
 }
 ```
-</Codeblock>
 
 Pour les fonctionnalités `init` et `init_if_needed`, nous créons un autre trait appelé `MintInit` que nous utilisons spécifiquement à cet effet en raison des champs uniques requis. Nous utilisons ensuite les CPIs `CreateAccount` et `InitializeMint2` pour initialiser le compte de `Mint` :
 
-<Codeblock lang="rust">
 ```rust
 pub trait MintInit {
     fn init(account: &AccountInfo, payer: &AccountInfo, decimals: u8, mint_authority: &[u8; 32], freeze_authority: Option<&[u8; 32]>) -> ProgramResult;
@@ -185,12 +179,10 @@ impl MintInit for MintAccount {
     }
 }
 ```
-</Codeblock>
 
 
 Nous faisons ensuite exactement la même chose pour le `TokenAccount` :
 
-<Codeblock lang="rust">
 ```rust
 pub struct TokenAccount;
 
@@ -243,7 +235,6 @@ impl AccountInit for TokenAccount {
     }
 }
 ```
-</Codeblock>
 
 ### Token2022
 
@@ -257,7 +248,6 @@ Pour Token2022, nous pouvons distinguer un `Mint` d'un `TokenAccount` de deux ma
 
 Cela conduit à des contrôles de validation modifiés :
 
-<Codeblock lang="rust">
 ```rust
 // TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb
 pub const TOKEN_2022_PROGRAM_ID: [u8; 32] = [
@@ -373,13 +363,11 @@ impl AccountInit for TokenAccount2022Account {
     }
 }
 ```
-</Codeblock>
 
 ### Interface de Jeton
 
 Comme nous voulons faciliter l'utilisation des Programmes Token2022 et Legacy Token sans avoir à faire de distinction entre eux, nous avons créé une fonction d'aide qui suit le même principe de base :
 
-<Codeblock lang="rust">
 ```rust
 pub struct MintInterface;
 
@@ -441,13 +429,11 @@ impl AccountCheck for TokenAccountInterface {
     }
 }
 ```
-</Codeblock>
 
 ### Compte de Jetons Associé
 
 Nous pouvons créer des contrôles pour le Programme de Jetons Associés. Ces vérifications sont très similaires aux vérifications du Programme de Jetons mais elles incluent une vérification de dérivation supplémentaire afin de s'assurer que le compte est correctement dérivé.
 
-<Codeblock lang="rust">
 ```rust
 pub struct AssociatedTokenAccount;
 
@@ -494,7 +480,6 @@ impl AssociatedTokenAccountInit for AssociatedTokenAccount {
     }
 }
 ```
-</Codeblock>
 
 <ArticleSection name="Comptes de Programme" id="program-accounts" level="h2" />
 
@@ -504,7 +489,6 @@ Vous remarquerez peut-être quelque chose d'intéressant dans notre implémentat
 
 Une attaque par réinitialisation se produit lorsqu'un attaquant tente de réutiliser un compte fermé en le réinitialisant avec des données malveillantes. En définissant le premier octet sur 255 et en réduisant le compte à une taille proche de zéro, nous rendons impossible toute confusion future entre ce compte et un type de compte valide. Il s'agit d'un pattern de sécurité courant dans les programmes Solana.
 
-<Codeblock lang="rust">
   ```rust
   pub struct ProgramAccount;
 
@@ -575,7 +559,6 @@ Une attaque par réinitialisation se produit lorsqu'un attaquant tente de réuti
       }
   }
   ```
-</Codeblock>
 
 ### Optimisation de l'Accès aux Données du Compte
 

--- a/src/app/content/courses/introduction-to-pinocchio/pinocchio-accounts/vi.mdx
+++ b/src/app/content/courses/introduction-to-pinocchio/pinocchio-accounts/vi.mdx
@@ -1,5 +1,4 @@
 import { ArticleSection } from "../../../../components/ArticleSection/ArticleSection";
-import { Codeblock } from "../../../../components/Codeblock/Codeblock";
 
 # Các Account
 
@@ -89,7 +88,6 @@ Bây giờ hãy xem cách chúng ta áp dụng điều này vào các kiểm tra
 
 Như chúng ta đã thấy trong các ví dụ trước, kiểm tra `SystemAccount` và `SignerAccount` rất đơn giản và không yêu cầu bất kỳ xác thực bổ sung nào, vì vậy chúng ta sẽ thêm những điều sau vào `helper.rs` của chúng ta:
 
-<Codeblock lang="rust">
 ```rust
 pub trait AccountCheck {
     fn check(account: &AccountInfo) -> Result<(), ProgramError>;
@@ -118,7 +116,6 @@ impl AccountCheck for SystemAccount {
     }
 }
 ```
-</Codeblock>
 
 Ở đây chúng ta chỉ đơn giản kiểm tra xem account có phải là signer hay nó có được sở hữu bởi system program không. Chú ý cách cả hai struct đều cung cấp cùng một phương thức check, mang lại cho chúng ta common interface mà chúng ta đã nói đến.
 
@@ -126,7 +123,6 @@ impl AccountCheck for SystemAccount {
 
 Bây giờ mọi thứ trở nên thú vị hơn. Chúng ta bắt đầu với trait `AccountCheck` thông thường, nhưng chúng ta cũng thêm các trait cụ thể khác để cung cấp các helper bổ sung giống với các macro Anchor như `init` và `init_if_needed`.
 
-<Codeblock lang="rust">
 ```rust
 pub struct MintAccount;
 
@@ -144,11 +140,9 @@ impl AccountCheck for MintAccount {
     }
 }
 ```
-</Codeblock>
 
 Đối với chức năng `init` và `init_if_needed`, chúng ta tạo một trait khác gọi là `MintInit` mà chúng ta sử dụng cụ thể cho mục đích này vì các trường duy nhất được yêu cầu. Sau đó chúng ta sử dụng CPI `CreateAccount` và `InitializeMint2` để khởi tạo account `Mint`:
 
-<Codeblock lang="rust">
 ```rust
 pub trait MintInit {
     fn init(account: &AccountInfo, payer: &AccountInfo, decimals: u8, mint_authority: &[u8; 32], freeze_authority: Option<&[u8; 32]>) -> ProgramResult;
@@ -185,12 +179,10 @@ impl MintInit for MintAccount {
     }
 }
 ```
-</Codeblock>
 
 
 Sau đó chúng ta làm chính xác như vậy cho `TokenAccount`:
 
-<Codeblock lang="rust">
 ```rust
 pub struct TokenAccount;
 
@@ -243,7 +235,6 @@ impl AccountInit for TokenAccount {
     }
 }
 ```
-</Codeblock>
 
 ### Token2022
 
@@ -257,7 +248,6 @@ Bạn có thể đã nhận thấy rằng đối với Legacy SPL Token Program,
 
 Điều này dẫn đến các kiểm tra xác thực được sửa đổi:
 
-<Codeblock lang="rust">
 ```rust
 // TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb
 pub const TOKEN_2022_PROGRAM_ID: [u8; 32] = [
@@ -373,13 +363,11 @@ impl AccountInit for TokenAccount2022Account {
     }
 }
 ```
-</Codeblock>
 
 ### Token Interface
 
 Vì chúng ta muốn khiến cho việc làm việc với cả Token2022 và Legacy Token Program trở nên dễ dàng mà không cần phân biệt giữa chúng, chúng ta đã tạo một helper tuân theo cùng nguyên tắc cơ bản:
 
-<Codeblock lang="rust">
 ```rust
 pub struct MintInterface;
 
@@ -441,13 +429,11 @@ impl AccountCheck for TokenAccountInterface {
     }
 }
 ```
-</Codeblock>
 
 ### Associated Token Account
 
 Chúng ta có thể tạo một số kiểm tra cho Associated Token Program. Chúng rất giống với các kiểm tra Token Program thông thường, nhưng chúng bao gồm một kiểm tra derivation bổ sung để đảm bảo account được derive một cách chính xác.
 
-<Codeblock lang="rust">
 ```rust
 pub struct AssociatedTokenAccount;
 
@@ -494,7 +480,6 @@ impl AssociatedTokenAccountInit for AssociatedTokenAccount {
     }
 }
 ```
-</Codeblock>
 
 <ArticleSection name="Các tài khoản của chương trình" id="program-accounts" level="h2" />
 
@@ -504,7 +489,6 @@ Bạn có thể nhận thấy điều gì đó thú vị trong triển khai `clo
 
 Một cuộc tấn công tái khởi tạo xảy ra khi kẻ tấn công cố gắng tái sử dụng một account đã đóng bằng cách khởi tạo lại nó với dữ liệu độc hại. Bằng cách đặt byte đầu tiên thành 255 và thu nhỏ account xuống gần như kích thước bằng không, chúng ta làm cho account không thể bị nhầm lẫn với bất kỳ kiểu account hợp lệ nào trong tương lai. Đây là một pattern bảo mật phổ biến trong các chương trình Solana.
 
-<Codeblock lang="rust">
   ```rust
   pub struct ProgramAccount;
 
@@ -575,7 +559,6 @@ Một cuộc tấn công tái khởi tạo xảy ra khi kẻ tấn công cố g�
       }
   }
   ```
-</Codeblock>
 
 ### Tối ưu hóa việc truy cập dữ liệu của Account
 

--- a/src/app/content/courses/introduction-to-pinocchio/pinocchio-accounts/zh-CN.mdx
+++ b/src/app/content/courses/introduction-to-pinocchio/pinocchio-accounts/zh-CN.mdx
@@ -1,5 +1,4 @@
 import { ArticleSection } from "../../../../components/ArticleSection/ArticleSection";
-import { Codeblock } from "../../../../components/Codeblock/Codeblock";
 
 # 账户
 
@@ -89,7 +88,6 @@ impl AccountCheck for SystemAccount {
 
 正如我们在之前的示例中看到的，`SystemAccount` 和 `SignerAccount` 检查非常简单，不需要任何额外的验证，因此我们将在 `helper.rs` 中添加以下内容：
 
-<Codeblock lang="rust">
 
 ```rust
 pub trait AccountCheck {
@@ -120,7 +118,6 @@ impl AccountCheck for SystemAccount {
 }
 ```
 
-</Codeblock>
 
 这里我们只是检查账户是否是签名者，或者是否由系统程序拥有。请注意，这两个结构体都提供了相同的检查方法，为我们提供了前面提到的通用接口。
 
@@ -128,7 +125,6 @@ impl AccountCheck for SystemAccount {
 
 现在事情变得更有趣了。我们从常规的 `AccountCheck` trait 开始，但我们还添加了其他特定的 traits，以提供类似于 Anchor 宏的额外辅助功能，例如 `init` 和 `init_if_needed`。
 
-<Codeblock lang="rust">
 
 ```rust
 pub struct MintAccount;
@@ -148,11 +144,9 @@ impl AccountCheck for MintAccount {
 }
 ```
 
-</Codeblock>
 
 对于 `init` 和 `init_if_needed` 的功能，我们创建了另一个名为 `MintInit` 的 trait，专门用于此目的，因为它需要独特的字段。然后我们使用 `CreateAccount` 和 `InitializeMint2` CPI 来初始化 `Mint` 账户：
 
-<Codeblock lang="rust">
 
 ```rust
 pub trait MintInit {
@@ -191,11 +185,9 @@ impl MintInit for MintAccount {
 }
 ```
 
-</Codeblock>
 
 然后我们对 `TokenAccount` 执行完全相同的操作：
 
-<Codeblock lang="rust">
 
 ```rust
 pub struct TokenAccount;
@@ -250,7 +242,6 @@ impl AccountInit for TokenAccount {
 }
 ```
 
-</Codeblock>
 
 ### Token2022
 
@@ -264,7 +255,6 @@ impl AccountInit for TokenAccount {
 
 这导致了修改后的验证检查：
 
-<Codeblock lang="rust">
 
 ```rust
 // TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb
@@ -382,13 +372,11 @@ impl AccountInit for TokenAccount2022Account {
 }
 ```
 
-</Codeblock>
 
 ### Token 接口
 
 为了让 Token2022 和传统的 Token Programs 更容易一起使用，而无需在它们之间进行区分，我们创建了一个遵循相同基本原则的辅助工具：
 
-<Codeblock lang="rust">
 
 ```rust
 pub struct MintInterface;
@@ -452,13 +440,11 @@ impl AccountCheck for TokenAccountInterface {
 }
 ```
 
-</Codeblock>
 
 ### 关联 Token 账户
 
 我们可以为 Associated Token Program 创建一些检查。这些检查与普通的 Token Program 检查非常相似，但它们包括一个额外的派生检查，以确保账户被正确派生。
 
-<Codeblock lang="rust">
 
 ```rust
 pub struct AssociatedTokenAccount;
@@ -507,7 +493,6 @@ impl AssociatedTokenAccountInit for AssociatedTokenAccount {
 }
 ```
 
-</Codeblock>
 
 <ArticleSection name="Program Accounts" id="program-accounts" level="h2" />
 
@@ -517,7 +502,6 @@ impl AssociatedTokenAccountInit for AssociatedTokenAccount {
 
 重新初始化攻击是指攻击者试图通过重新初始化已关闭的账户并注入恶意数据来重新利用该账户。通过将第一个字节设置为 255 并将账户缩小到几乎为零的大小，我们可以确保该账户在未来不会被误认为任何有效的账户类型。这是 Solana 程序中常见的安全模式。
 
-<Codeblock lang="rust">
 
   ```rust
   pub struct ProgramAccount;
@@ -590,7 +574,6 @@ impl AssociatedTokenAccountInit for AssociatedTokenAccount {
   }
   ```
 
-</Codeblock>
 
 ### 优化账户数据访问
 

--- a/src/app/content/courses/introduction-to-pinocchio/pinocchio-errors/en.mdx
+++ b/src/app/content/courses/introduction-to-pinocchio/pinocchio-errors/en.mdx
@@ -1,5 +1,4 @@
 import { ArticleSection } from "../../../../components/ArticleSection/ArticleSection";
-import { Codeblock } from "../../../../components/Codeblock/Codeblock";
 
 # Errors
 

--- a/src/app/content/courses/introduction-to-pinocchio/pinocchio-errors/fr.mdx
+++ b/src/app/content/courses/introduction-to-pinocchio/pinocchio-errors/fr.mdx
@@ -1,5 +1,4 @@
 import { ArticleSection } from "../../../../components/ArticleSection/ArticleSection";
-import { Codeblock } from "../../../../components/Codeblock/Codeblock";
 
 # Erreurs
 

--- a/src/app/content/courses/introduction-to-pinocchio/pinocchio-errors/vi.mdx
+++ b/src/app/content/courses/introduction-to-pinocchio/pinocchio-errors/vi.mdx
@@ -1,5 +1,4 @@
 import { ArticleSection } from "../../../../components/ArticleSection/ArticleSection";
-import { Codeblock } from "../../../../components/Codeblock/Codeblock";
 
 # Error
 

--- a/src/app/content/courses/introduction-to-pinocchio/pinocchio-errors/zh-CN.mdx
+++ b/src/app/content/courses/introduction-to-pinocchio/pinocchio-errors/zh-CN.mdx
@@ -1,5 +1,4 @@
 import { ArticleSection } from "../../../../components/ArticleSection/ArticleSection";
-import { Codeblock } from "../../../../components/Codeblock/Codeblock";
 
 # 错误
 

--- a/src/app/content/courses/introduction-to-pinocchio/pinocchio-instructions/en.mdx
+++ b/src/app/content/courses/introduction-to-pinocchio/pinocchio-instructions/en.mdx
@@ -1,5 +1,4 @@
 import { ArticleSection } from "../../../../components/ArticleSection/ArticleSection";
-import { Codeblock } from "../../../../components/Codeblock/Codeblock";
 
 # Instructions
 

--- a/src/app/content/courses/introduction-to-pinocchio/pinocchio-instructions/fr.mdx
+++ b/src/app/content/courses/introduction-to-pinocchio/pinocchio-instructions/fr.mdx
@@ -1,5 +1,4 @@
 import { ArticleSection } from "../../../../components/ArticleSection/ArticleSection";
-import { Codeblock } from "../../../../components/Codeblock/Codeblock";
 
 # Instructions
 

--- a/src/app/content/courses/introduction-to-pinocchio/pinocchio-instructions/vi.mdx
+++ b/src/app/content/courses/introduction-to-pinocchio/pinocchio-instructions/vi.mdx
@@ -1,5 +1,4 @@
 import { ArticleSection } from "../../../../components/ArticleSection/ArticleSection";
-import { Codeblock } from "../../../../components/Codeblock/Codeblock";
 
 # Các Instruction
 

--- a/src/app/content/courses/introduction-to-pinocchio/pinocchio-instructions/zh-CN.mdx
+++ b/src/app/content/courses/introduction-to-pinocchio/pinocchio-instructions/zh-CN.mdx
@@ -1,5 +1,4 @@
 import { ArticleSection } from "../../../../components/ArticleSection/ArticleSection";
-import { Codeblock } from "../../../../components/Codeblock/Codeblock";
 
 # 指南
 

--- a/src/app/content/courses/introduction-to-pinocchio/reading-and-writing-data/en.mdx
+++ b/src/app/content/courses/introduction-to-pinocchio/reading-and-writing-data/en.mdx
@@ -1,5 +1,4 @@
 import { ArticleSection } from "../../../../components/ArticleSection/ArticleSection";
-import { Codeblock } from "../../../../components/Codeblock/Codeblock";
 
 # Reading and Writing Data
 

--- a/src/app/content/courses/introduction-to-pinocchio/reading-and-writing-data/fr.mdx
+++ b/src/app/content/courses/introduction-to-pinocchio/reading-and-writing-data/fr.mdx
@@ -1,5 +1,4 @@
 import { ArticleSection } from "../../../../components/ArticleSection/ArticleSection";
-import { Codeblock } from "../../../../components/Codeblock/Codeblock";
 
 # Lecture et Écriture des Données
 

--- a/src/app/content/courses/introduction-to-pinocchio/reading-and-writing-data/vi.mdx
+++ b/src/app/content/courses/introduction-to-pinocchio/reading-and-writing-data/vi.mdx
@@ -1,5 +1,4 @@
 import { ArticleSection } from "../../../../components/ArticleSection/ArticleSection";
-import { Codeblock } from "../../../../components/Codeblock/Codeblock";
 
 # Đọc và Ghi Dữ liệu
 

--- a/src/app/content/courses/introduction-to-pinocchio/reading-and-writing-data/zh-CN.mdx
+++ b/src/app/content/courses/introduction-to-pinocchio/reading-and-writing-data/zh-CN.mdx
@@ -1,5 +1,4 @@
 import { ArticleSection } from "../../../../components/ArticleSection/ArticleSection";
-import { Codeblock } from "../../../../components/Codeblock/Codeblock";
 
 # 读取和写入数据
 

--- a/src/app/content/courses/research-crateless-program/lesson/en.mdx
+++ b/src/app/content/courses/research-crateless-program/lesson/en.mdx
@@ -1,5 +1,4 @@
 import { ArticleSection } from "../../../../components/ArticleSection/ArticleSection";
-import { Codeblock } from "../../../../components/Codeblock/Codeblock";
 
 # Byte by Byte: The Anatomy of a Crateless Program
 

--- a/src/app/content/courses/research-crateless-program/lesson/vi.mdx
+++ b/src/app/content/courses/research-crateless-program/lesson/vi.mdx
@@ -1,5 +1,4 @@
 import { ArticleSection } from "../../../../components/ArticleSection/ArticleSection";
-import { Codeblock } from "../../../../components/Codeblock/Codeblock";
 
 # Byte by Byte: The Anatomy of a Crateless Program
 

--- a/src/app/content/courses/research-crateless-program/lesson/zh-CN.mdx
+++ b/src/app/content/courses/research-crateless-program/lesson/zh-CN.mdx
@@ -1,5 +1,4 @@
 import { ArticleSection } from "../../../../components/ArticleSection/ArticleSection";
-import { Codeblock } from "../../../../components/Codeblock/Codeblock";
 
 # 字节解析：无 Crate 程序的结构剖析
 

--- a/src/app/content/courses/secp256r1-on-solana/introduction/en.mdx
+++ b/src/app/content/courses/secp256r1-on-solana/introduction/en.mdx
@@ -1,5 +1,4 @@
 import { ArticleSection } from "../../../../components/ArticleSection/ArticleSection";
-import { Codeblock } from "../../../../components/Codeblock/Codeblock";
 
 # Secp256r1 on Solana
 

--- a/src/app/content/courses/secp256r1-on-solana/introduction/fr.mdx
+++ b/src/app/content/courses/secp256r1-on-solana/introduction/fr.mdx
@@ -1,5 +1,4 @@
 import { ArticleSection } from "../../../../components/ArticleSection/ArticleSection";
-import { Codeblock } from "../../../../components/Codeblock/Codeblock";
 
 # Secp256r1 sur Solana
 

--- a/src/app/content/courses/secp256r1-on-solana/introduction/vi.mdx
+++ b/src/app/content/courses/secp256r1-on-solana/introduction/vi.mdx
@@ -1,5 +1,4 @@
 import { ArticleSection } from "../../../../components/ArticleSection/ArticleSection";
-import { Codeblock } from "../../../../components/Codeblock/Codeblock";
 
 # Secp256r1 trên Solana
 

--- a/src/app/content/courses/secp256r1-on-solana/introduction/zh-CN.mdx
+++ b/src/app/content/courses/secp256r1-on-solana/introduction/zh-CN.mdx
@@ -1,5 +1,4 @@
 import { ArticleSection } from "../../../../components/ArticleSection/ArticleSection";
-import { Codeblock } from "../../../../components/Codeblock/Codeblock";
 
 # Solana 上的 Secp256r1
 

--- a/src/app/content/courses/secp256r1-on-solana/secp256r1-with-anchor/en.mdx
+++ b/src/app/content/courses/secp256r1-on-solana/secp256r1-with-anchor/en.mdx
@@ -1,4 +1,3 @@
 import { ArticleSection } from "../../../../components/ArticleSection/ArticleSection";
-import { Codeblock } from "../../../../components/Codeblock/Codeblock";
 
 # COMING SOON...

--- a/src/app/content/courses/secp256r1-on-solana/secp256r1-with-anchor/fr.mdx
+++ b/src/app/content/courses/secp256r1-on-solana/secp256r1-with-anchor/fr.mdx
@@ -1,4 +1,3 @@
 import { ArticleSection } from "../../../../components/ArticleSection/ArticleSection";
-import { Codeblock } from "../../../../components/Codeblock/Codeblock";
 
 # À VENIR...

--- a/src/app/content/courses/secp256r1-on-solana/secp256r1-with-anchor/vi.mdx
+++ b/src/app/content/courses/secp256r1-on-solana/secp256r1-with-anchor/vi.mdx
@@ -1,4 +1,3 @@
 import { ArticleSection } from "../../../../components/ArticleSection/ArticleSection";
-import { Codeblock } from "../../../../components/Codeblock/Codeblock";
 
 # SẮP RA MẮT...

--- a/src/app/content/courses/secp256r1-on-solana/secp256r1-with-anchor/zh-CN.mdx
+++ b/src/app/content/courses/secp256r1-on-solana/secp256r1-with-anchor/zh-CN.mdx
@@ -1,4 +1,3 @@
 import { ArticleSection } from "../../../../components/ArticleSection/ArticleSection";
-import { Codeblock } from "../../../../components/Codeblock/Codeblock";
 
 # 即将推出...

--- a/src/app/content/courses/secp256r1-on-solana/secp256r1-with-pinocchio/en.mdx
+++ b/src/app/content/courses/secp256r1-on-solana/secp256r1-with-pinocchio/en.mdx
@@ -1,5 +1,4 @@
 import { ArticleSection } from "../../../../components/ArticleSection/ArticleSection";
-import { Codeblock } from "../../../../components/Codeblock/Codeblock";
 
 # Secp256r1 with Pinocchio
 

--- a/src/app/content/courses/secp256r1-on-solana/secp256r1-with-pinocchio/fr.mdx
+++ b/src/app/content/courses/secp256r1-on-solana/secp256r1-with-pinocchio/fr.mdx
@@ -1,5 +1,4 @@
 import { ArticleSection } from "../../../../components/ArticleSection/ArticleSection";
-import { Codeblock } from "../../../../components/Codeblock/Codeblock";
 
 # Secp256r1 avec Pinocchio
 

--- a/src/app/content/courses/secp256r1-on-solana/secp256r1-with-pinocchio/vi.mdx
+++ b/src/app/content/courses/secp256r1-on-solana/secp256r1-with-pinocchio/vi.mdx
@@ -1,5 +1,4 @@
 import { ArticleSection } from "../../../../components/ArticleSection/ArticleSection";
-import { Codeblock } from "../../../../components/Codeblock/Codeblock";
 
 # Secp256r1 với Pinocchio
 

--- a/src/app/content/courses/secp256r1-on-solana/secp256r1-with-pinocchio/zh-CN.mdx
+++ b/src/app/content/courses/secp256r1-on-solana/secp256r1-with-pinocchio/zh-CN.mdx
@@ -1,5 +1,4 @@
 import { ArticleSection } from "../../../../components/ArticleSection/ArticleSection";
-import { Codeblock } from "../../../../components/Codeblock/Codeblock";
 
 # Secp256r1 与 Pinocchio
 

--- a/src/app/content/courses/solana-pay/transaction-request/en.mdx
+++ b/src/app/content/courses/solana-pay/transaction-request/en.mdx
@@ -1,5 +1,4 @@
 import { ArticleSection } from "../../../../components/ArticleSection/ArticleSection";
-import { Codeblock } from "../../../../components/Codeblock/Codeblock";
 
 # Transaction Request
 

--- a/src/app/content/courses/solana-pay/transaction-request/vi.mdx
+++ b/src/app/content/courses/solana-pay/transaction-request/vi.mdx
@@ -1,5 +1,4 @@
 import { ArticleSection } from "../../../../components/ArticleSection/ArticleSection";
-import { Codeblock } from "../../../../components/Codeblock/Codeblock";
 
 # Yêu cầu Transaction
 

--- a/src/app/content/courses/testing-with-litesvm/rust/en.mdx
+++ b/src/app/content/courses/testing-with-litesvm/rust/en.mdx
@@ -8,11 +8,9 @@ The `litesvm` package provides the core testing infrastructure for creating a li
 
 Add LiteSVM to your project:
 
-<Codeblock lang="terminal">
 ```bash
 cargo add --dev litesvm
 ```
-</Codeblock>
 
 <ArticleSection name="LiteSVM Basics" id="basics" level="h2" />
 

--- a/src/app/content/courses/testing-with-litesvm/typescript/en.mdx
+++ b/src/app/content/courses/testing-with-litesvm/typescript/en.mdx
@@ -8,11 +8,9 @@ The `litesvm` package provides the core testing infrastructure for creating a li
 
 Add LiteSVM to your project:
 
-<Codeblock lang="terminal">
 ```bash
 npm i --save-dev litesvm
 ```
-</Codeblock>
 
 <ArticleSection name="LiteSVM Basics" id="basics" level="h2" />
 

--- a/src/app/content/courses/testing-with-surfpool/advanced-functionalities/en.mdx
+++ b/src/app/content/courses/testing-with-surfpool/advanced-functionalities/en.mdx
@@ -27,7 +27,6 @@ await fetch(connection.rpcEndpoint, {
 
 To execute RPC calls in your terminal, use:
 
-<Codeblock lang="terminal">
 ```bash
 curl -X POST \
     -H "Content-Type: application/json" \
@@ -39,7 +38,6 @@ curl -X POST \
     }' \
     http://localhost:8899
 ```
-</Codeblock>
 
 <ArticleSection name="Customize System Variables" id="customize-system-variables" level="h2" />
 

--- a/src/app/content/courses/testing-with-surfpool/surfpool-101/en.mdx
+++ b/src/app/content/courses/testing-with-surfpool/surfpool-101/en.mdx
@@ -27,11 +27,9 @@ Everything you need to run Surfnet is included in the Surfpool SDK. Since instal
 
 After installing the Surfpool SDK, start Surfnet with:
 
-<Codeblock lang="terminal">
 ```bash
 surfpool start
 ```
-</Codeblock>
 
 This starts Surfnet on the standard local validator port (`http://127.0.0.1:8899`) with a terminal UI displaying:
 - **Slots and Epoch**: Currently executing slots process automatically every 400ms. Use **Tab** to manually advance to the next slot, or **Spacebar** to pause/resume automatic block production


### PR DESCRIPTION
The current approach of forcing code block to be wrapped inside a pair of Codeblock tags to get copy functionality and a more stylized frame around code snippets is causing a lot of issue with code editor and AI.

The solution is to hook ``` to directly generate the body of the Codeblock component, so the output is transparently handled by the MDX compiler. This approach results in a simpler and more consistent content production experience, and keeps both editors and AI happy.