### PR TITLE
feat: improve code block readability

### DIFF
--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -10,15 +10,15 @@ import GlobalModals from "@/app/components/Modals/GlobalModals";
 import { AuthProvider } from "@/contexts/AuthContext";
 import WalletProvider from "@/contexts/WalletProvider";
 import TanstackProvider from "@/contexts/TanstackProvider";
-import { Geist_Mono, Funnel_Display } from "next/font/google";
+import { Fira_Code, Funnel_Display } from "next/font/google";
 import { GoogleAnalytics } from "@next/third-parties/google";
 import { headers } from "next/headers";
 import { Toaster } from "react-hot-toast";
 import Icon from "@/app/components/Icon/Icon";
 
-const GeistMono = Geist_Mono({
+const FiraCode = Fira_Code({
   subsets: ["latin"],
-  variable: "--font-geist-mono",
+  variable: "--font-fira-code",
   display: "swap",
 });
 
@@ -109,7 +109,7 @@ export default async function RootLayout({
   return (
     <html lang={locale}>
       <body
-        className={`${MontechV2.variable} ${GeistMono.variable} ${FunnelDisplay.variable} ${Switzer.variable} antialiased`}
+        className={`${MontechV2.variable} ${FiraCode.variable} ${FunnelDisplay.variable} ${Switzer.variable} antialiased`}
       >
         <NextIntlClientProvider>
           <TanstackProvider>

--- a/src/app/components/Challenges/ClientChallengeTable.tsx
+++ b/src/app/components/Challenges/ClientChallengeTable.tsx
@@ -143,7 +143,7 @@ export default function ChallengeTable({
                 <div className="px-2 w-full">
                   <Divider />
                 </div>
-                <div className="max-w-full sm:max-w-[450px] overflow-x-scroll flex flex-col gap-y-1 items-start px-3 pr-5 pb-2 w-max max-h-80 custom-scrollbar font-geist-mono text-xs">
+                <div className="max-w-full sm:max-w-[450px] overflow-x-scroll flex flex-col gap-y-1 items-start px-3 pr-5 pb-2 w-max max-h-80 custom-scrollbar font-fira-code text-xs">
                   {runnerLogs.map((log, index) => (
                     <motion.div
                       key={index}
@@ -325,7 +325,7 @@ export default function ChallengeTable({
                                     ease: anticipate,
                                     delay: 0.8,
                                   }}
-                                  className="text-start w-full font-geist-mono font-medium text-nowrap text-[#FF5555]"
+                                  className="text-start w-full font-fira-code font-medium text-nowrap text-[#FF5555]"
                                 >
                                   {
                                     verificationData.results.find(
@@ -353,7 +353,7 @@ export default function ChallengeTable({
                                       delay: 1 + index * 0.1,
                                     }}
                                     key={index}
-                                    className="text-start font-geist-mono font-medium text-nowrap text-secondary"
+                                    className="text-start font-fira-code font-medium text-nowrap text-secondary"
                                   >
                                     {log.slice(7, log.length)}
                                   </motion.span>

--- a/src/app/components/Challenges/ProgramChallengeTable.tsx
+++ b/src/app/components/Challenges/ProgramChallengeTable.tsx
@@ -502,7 +502,7 @@ export default function ChallengeTable({
                                       ease: anticipate,
                                       delay: 0.8,
                                     }}
-                                    className="text-start w-full font-geist-mono font-medium text-nowrap text-[#FF5555]"
+                                    className="text-start w-full font-fira-code font-medium text-nowrap text-[#FF5555]"
                                   >
                                     {
                                       verificationData.results.find(
@@ -530,7 +530,7 @@ export default function ChallengeTable({
                                       delay: 1 + index * 0.1,
                                     }}
                                     key={index}
-                                    className="text-start font-geist-mono font-medium text-nowrap text-secondary"
+                                    className="text-start font-fira-code font-medium text-nowrap text-secondary"
                                   >
                                     {log.slice(7, log.length)}
                                   </motion.span>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -22,7 +22,7 @@
   --color-brand-typescript: #69a2f1;
   --font-sans: var(--font-funnel-display);
   --font-mono: var(--font-montech);
-  --font-geist-mono: var(--font-geist-mono);
+  --font-fira-code: var(--font-fira-code);
   --font-content: var(--font-switzer);
   --text-3xl: 32px;
   --container-app: 1500px;
@@ -140,6 +140,7 @@ h2 code {
   scrollbar-width: thin;
   scrollbar-color: var(--color-background-card-foreground) transparent;
 }
+
 
 .rehype-pretty-copy {
   @apply opacity-0;

--- a/src/app/mdx-layout.tsx
+++ b/src/app/mdx-layout.tsx
@@ -25,7 +25,7 @@ export default function MdxLayout({ children }: { children: React.ReactNode }) {
       prose-blockquote:[font-style:normal]
       prose-blockquote:border-l-2
       prose-figure:my-0
-      prose-code:[font-family:var(--font-geist-mono)]
+      prose-code:[font-family:var(--font-fira-code)]
       prose-code:font-medium
       prose-code:text-brand-secondary
       prose-code:before:hidden


### PR DESCRIPTION
# Problem

Geist Mono and other beautiful mono space fonts do not have proper monospace alignment, making some of the ASCII drawings and listings difficult to read:

<img width="720" height="201" alt="image" src="https://github.com/user-attachments/assets/25f565dd-6f4c-4482-802a-8796be83eb76" />

# Solution

Change to Fira Code

<img width="720" height="201" alt="image" src="https://github.com/user-attachments/assets/5ee1aa5d-c2e6-49b2-9445-dbd8fbb26de9" />
