### PR TITLE
refactor: use `pubkey_eq` in pinocchio

### DIFF
--- a/src/app/content/challenges/pinocchio-flash-loan/de/pages/borrow.mdx
+++ b/src/app/content/challenges/pinocchio-flash-loan/de/pages/borrow.mdx
@@ -32,7 +32,7 @@ impl<'a> TryFrom<&'a [AccountInfo]> for LoanAccounts<'a> {
             return Err(ProgramError::NotEnoughAccountKeys);
         };
 
-        if instruction_sysvar.key() != &INSTRUCTIONS_ID {
+        if !pubkey_eq(instruction_sysvar.key(), &INSTRUCTIONS_ID) {
             return Err(ProgramError::UnsupportedSysvar);
         }
 

--- a/src/app/content/challenges/pinocchio-flash-loan/en/pages/borrow.mdx
+++ b/src/app/content/challenges/pinocchio-flash-loan/en/pages/borrow.mdx
@@ -32,7 +32,7 @@ impl<'a> TryFrom<&'a [AccountInfo]> for LoanAccounts<'a> {
             return Err(ProgramError::NotEnoughAccountKeys);
         };
 
-        if instruction_sysvar.key() != &INSTRUCTIONS_ID {
+        if !pubkey_eq(instruction_sysvar.key(), &INSTRUCTIONS_ID) {
             return Err(ProgramError::UnsupportedSysvar);
         }
 

--- a/src/app/content/challenges/pinocchio-flash-loan/fr/pages/borrow.mdx
+++ b/src/app/content/challenges/pinocchio-flash-loan/fr/pages/borrow.mdx
@@ -32,7 +32,7 @@ impl<'a> TryFrom<&'a [AccountInfo]> for LoanAccounts<'a> {
             return Err(ProgramError::NotEnoughAccountKeys);
         };
         
-        if instruction_sysvar.key() != &INSTRUCTIONS_ID {
+        if !pubkey_eq(instruction_sysvar.key(), &INSTRUCTIONS_ID) {
             return Err(ProgramError::UnsupportedSysvar);
         }
 

--- a/src/app/content/challenges/pinocchio-flash-loan/id/pages/borrow.mdx
+++ b/src/app/content/challenges/pinocchio-flash-loan/id/pages/borrow.mdx
@@ -32,7 +32,7 @@ impl<'a> TryFrom<&'a [AccountInfo]> for LoanAccounts<'a> {
             return Err(ProgramError::NotEnoughAccountKeys);
         };
 
-        if instruction_sysvar.key() != &INSTRUCTIONS_ID {
+        if !pubkey_eq(instruction_sysvar.key(), &INSTRUCTIONS_ID) {
             return Err(ProgramError::UnsupportedSysvar);
         }
 

--- a/src/app/content/challenges/pinocchio-flash-loan/uk/pages/borrow.mdx
+++ b/src/app/content/challenges/pinocchio-flash-loan/uk/pages/borrow.mdx
@@ -32,7 +32,7 @@ impl<'a> TryFrom<&'a [AccountInfo]> for LoanAccounts<'a> {
             return Err(ProgramError::NotEnoughAccountKeys);
         };
 
-        if instruction_sysvar.key() != &INSTRUCTIONS_ID {
+        if !pubkey_eq(instruction_sysvar.key(), &INSTRUCTIONS_ID) {
             return Err(ProgramError::UnsupportedSysvar);
         }
 

--- a/src/app/content/challenges/pinocchio-flash-loan/vi/pages/borrow.mdx
+++ b/src/app/content/challenges/pinocchio-flash-loan/vi/pages/borrow.mdx
@@ -32,7 +32,7 @@ impl<'a> TryFrom<&'a [AccountInfo]> for LoanAccounts<'a> {
             return Err(ProgramError::NotEnoughAccountKeys);
         };
 
-        if instruction_sysvar.key() != &INSTRUCTIONS_ID {
+        if !pubkey_eq(instruction_sysvar.key(), &INSTRUCTIONS_ID) {
             return Err(ProgramError::UnsupportedSysvar);
         }
 

--- a/src/app/content/challenges/pinocchio-flash-loan/zh-CN/pages/borrow.mdx
+++ b/src/app/content/challenges/pinocchio-flash-loan/zh-CN/pages/borrow.mdx
@@ -32,7 +32,7 @@ impl<'a> TryFrom<&'a [AccountInfo]> for LoanAccounts<'a> {
             return Err(ProgramError::NotEnoughAccountKeys);
         };
 
-        if instruction_sysvar.key() != &INSTRUCTIONS_ID {
+        if !pubkey_eq(instruction_sysvar.key(), &INSTRUCTIONS_ID) {
             return Err(ProgramError::UnsupportedSysvar);
         }
 

--- a/src/app/content/challenges/pinocchio-flash-loan/zh-HK/pages/borrow.mdx
+++ b/src/app/content/challenges/pinocchio-flash-loan/zh-HK/pages/borrow.mdx
@@ -32,7 +32,7 @@ impl<'a> TryFrom<&'a [AccountInfo]> for LoanAccounts<'a> {
             return Err(ProgramError::NotEnoughAccountKeys);
         };
 
-        if instruction_sysvar.key() != &INSTRUCTIONS_ID {
+        if !pubkey_eq(instruction_sysvar.key(), &INSTRUCTIONS_ID) {
             return Err(ProgramError::UnsupportedSysvar);
         }
 

--- a/src/app/content/courses/instruction-introspection/introspection-with-pinocchio/de.mdx
+++ b/src/app/content/courses/instruction-introspection/introspection-with-pinocchio/de.mdx
@@ -59,7 +59,7 @@ Wir können dann weitere programmspezifische Prüfungen basierend auf der Logik 
 Wir können auch die Konten überprüfen, die in der analysierten Anweisung vorhanden sind. Dieser Schritt erfordert, dass wir die genaue Struktur der Kontostruktur kennen, da wir die Daten oder den öffentlichen Schlüssel eines Kontos an einem bestimmten Index abfragen werden, wie hier:
 
 ```rust
-if instruction.get_account_meta_at(0)?.key() != self.accounts.from.key() {
+if !pubkey_eq(instruction.get_account_meta_at(0)?.key(), self.accounts.from.key()) {
     return Err(ProgramError::InvalidAccountData);
 }
 ```

--- a/src/app/content/courses/instruction-introspection/introspection-with-pinocchio/en.mdx
+++ b/src/app/content/courses/instruction-introspection/introspection-with-pinocchio/en.mdx
@@ -60,7 +60,7 @@ We can then perform more program-specific checks based on the logic of the instr
 We can also check the accounts present in the introspected instruction. This step requires us to know the exact structure of the account struct, since we'll be requesting the data or pubkey of an account at a specific index, like this:
 
 ```rust
-if instruction.get_account_meta_at(0)?.key() != self.accounts.from.key() {
+if !pubkey_eq(instruction.get_account_meta_at(0)?.key(), self.accounts.from.key()) {
     return Err(ProgramError::InvalidAccountData);
 }
 ```

--- a/src/app/content/courses/instruction-introspection/introspection-with-pinocchio/fr.mdx
+++ b/src/app/content/courses/instruction-introspection/introspection-with-pinocchio/fr.mdx
@@ -59,7 +59,7 @@ Nous pouvons ensuite effectuer des vérifications plus spécifiques au programme
 Nous pouvons également vérifier les comptes présents dans l'instruction introspectée. Cette étape nécessite de connaître la structure exacte de la structure de compte car nous allons demander les données ou la clé publique d'un compte à un index précis comme ceci :
 
 ```rust
-if instruction.get_account_meta_at(0)?.key() != self.accounts.from.key() {
+if !pubkey_eq(instruction.get_account_meta_at(0)?.key(), self.accounts.from.key()) {
     return Err(ProgramError::InvalidAccountData);
 }
 ```

--- a/src/app/content/courses/instruction-introspection/introspection-with-pinocchio/id.mdx
+++ b/src/app/content/courses/instruction-introspection/introspection-with-pinocchio/id.mdx
@@ -59,7 +59,7 @@ Kita kemudian dapat melakukan pemeriksaan yang lebih spesifik terhadap program b
 Kita juga dapat memeriksa akun-akun yang ada dalam instruksi yang diintrospeksi. Langkah ini mengharuskan kita mengetahui struktur pasti dari struct akun, karena kita akan meminta data atau pubkey dari akun pada indeks tertentu, seperti ini:
 
 ```rust
-if instruction.get_account_meta_at(0)?.key() != self.accounts.from.key() {
+if !pubkey_eq(instruction.get_account_meta_at(0)?.key(), self.accounts.from.key()) {
     return Err(ProgramError::InvalidAccountData);
 }
 ```

--- a/src/app/content/courses/instruction-introspection/introspection-with-pinocchio/uk.mdx
+++ b/src/app/content/courses/instruction-introspection/introspection-with-pinocchio/uk.mdx
@@ -60,7 +60,7 @@ if instruction.get_instruction_data() != instruction_data {
 Ми також можемо перевірити облікові записи, присутні в інструкції, яку ми аналізуємо. Цей крок вимагає знання точної структури структури облікового запису, оскільки ми будемо запитувати дані або публічний ключ облікового запису за певним індексом, ось так:
 
 ```rust
-if instruction.get_account_meta_at(0)?.key() != self.accounts.from.key() {
+if !pubkey_eq(instruction.get_account_meta_at(0)?.key(), self.accounts.from.key()) {
     return Err(ProgramError::InvalidAccountData);
 }
 ```

--- a/src/app/content/courses/instruction-introspection/introspection-with-pinocchio/vi.mdx
+++ b/src/app/content/courses/instruction-introspection/introspection-with-pinocchio/vi.mdx
@@ -59,7 +59,7 @@ Sau đó chúng ta có thể thực hiện các kiểm tra cụ thể cho chươ
 Chúng ta cũng có thể kiểm tra các tài khoản có mặt trong instruction được introspect. Bước này yêu cầu chúng ta phải biết cấu trúc chính xác của tài khoản, vì chúng ta sẽ yêu cầu dữ liệu hoặc pubkey của một tài khoản tại một chỉ số cụ thể, như thế này:
 
 ```rust
-if instruction.get_account_meta_at(0)?.key() != self.accounts.from.key() {
+if !pubkey_eq(instruction.get_account_meta_at(0)?.key(), self.accounts.from.key()) {
     return Err(ProgramError::InvalidAccountData);
 }
 ```

--- a/src/app/content/courses/instruction-introspection/introspection-with-pinocchio/zh-CN.mdx
+++ b/src/app/content/courses/instruction-introspection/introspection-with-pinocchio/zh-CN.mdx
@@ -59,7 +59,7 @@ if instruction.get_instruction_data() != instruction_data {
 我们还可以检查被内省的指令中存在的账户。此步骤要求我们了解账户结构的确切结构，因为我们需要在特定索引处请求账户的数据或公钥，如下所示：
 
 ```rust
-if instruction.get_account_meta_at(0)?.key() != self.accounts.from.key() {
+if !pubkey_eq(instruction.get_account_meta_at(0)?.key(), self.accounts.from.key()) {
     return Err(ProgramError::InvalidAccountData);
 }
 ```

--- a/src/app/content/courses/instruction-introspection/introspection-with-pinocchio/zh-HK.mdx
+++ b/src/app/content/courses/instruction-introspection/introspection-with-pinocchio/zh-HK.mdx
@@ -59,7 +59,7 @@ if instruction.get_instruction_data() != instruction_data {
 我們還可以檢查內省指令中存在的帳戶。此步驟需要我們了解帳戶結構的確切結構，因為我們將在特定索引處請求帳戶的數據或公鑰，如下所示：
 
 ```rust
-if instruction.get_account_meta_at(0)?.key() != self.accounts.from.key() {
+if !pubkey_eq(instruction.get_account_meta_at(0)?.key(), self.accounts.from.key()) {
     return Err(ProgramError::InvalidAccountData);
 }
 ```

--- a/src/app/content/courses/program-security/duplicate-mutable-accounts/de.mdx
+++ b/src/app/content/courses/program-security/duplicate-mutable-accounts/de.mdx
@@ -74,7 +74,7 @@ pub fn update_account(ctx: Context<UpdateAccount>, pubkey_a: Pubkey, pubkey_b: P
 Bei Pinocchio gilt das gleiche Validierungsmuster:
 
 ```rust
-if self.accounts.program_account_1.key() == self.accounts.program_account_2.key() {
+if pubkey_eq(self.accounts.program_account_1.key(), self.accounts.program_account_2.key()) {
     return Err(ProgramError::InvalidArgument)
 }
 ```

--- a/src/app/content/courses/program-security/duplicate-mutable-accounts/en.mdx
+++ b/src/app/content/courses/program-security/duplicate-mutable-accounts/en.mdx
@@ -74,7 +74,7 @@ pub fn update_account(ctx: Context<UpdateAccount>, pubkey_a: Pubkey, pubkey_b: P
 In Pinocchio, the same validation pattern applies:
 
 ```rust
-if self.accounts.program_account_1.key() == self.accounts.program_account_2.key() {
+if pubkey_eq(self.accounts.program_account_1.key(), self.accounts.program_account_2.key()) {
     return Err(ProgramError::InvalidArgument)
 }
 ```

--- a/src/app/content/courses/program-security/duplicate-mutable-accounts/fr.mdx
+++ b/src/app/content/courses/program-security/duplicate-mutable-accounts/fr.mdx
@@ -74,7 +74,7 @@ pub fn update_account(ctx: Context<UpdateAccount>, pubkey_a: Pubkey, pubkey_b: P
 Dans Pinocchio, le même modèle de validation s'applique :
 
 ```rust
-if self.accounts.program_account_1.key() == ctx.accounts.program_account_2.key() {
+if pubkey_eq(self.accounts.program_account_1.key(), self.accounts.program_account_2.key()) {
     return Err(ProgramError::InvalidArgument)
 }
 ```

--- a/src/app/content/courses/program-security/duplicate-mutable-accounts/id.mdx
+++ b/src/app/content/courses/program-security/duplicate-mutable-accounts/id.mdx
@@ -74,7 +74,7 @@ pub fn update_account(ctx: Context<UpdateAccount>, pubkey_a: Pubkey, pubkey_b: P
 Dalam Pinocchio, pola validasi yang sama berlaku:
 
 ```rust
-if self.accounts.program_account_1.key() == self.accounts.program_account_2.key() {
+if pubkey_eq(self.accounts.program_account_1.key(), self.accounts.program_account_2.key()) {
     return Err(ProgramError::InvalidArgument)
 }
 ```

--- a/src/app/content/courses/program-security/duplicate-mutable-accounts/uk.mdx
+++ b/src/app/content/courses/program-security/duplicate-mutable-accounts/uk.mdx
@@ -74,7 +74,7 @@ pub fn update_account(ctx: Context<UpdateAccount>, pubkey_a: Pubkey, pubkey_b: P
 У Pinocchio застосовується той самий шаблон валідації:
 
 ```rust
-if self.accounts.program_account_1.key() == self.accounts.program_account_2.key() {
+if pubkey_eq(self.accounts.program_account_1.key(), self.accounts.program_account_2.key()) {
     return Err(ProgramError::InvalidArgument)
 }
 ```

--- a/src/app/content/courses/program-security/duplicate-mutable-accounts/vi.mdx
+++ b/src/app/content/courses/program-security/duplicate-mutable-accounts/vi.mdx
@@ -74,7 +74,7 @@ pub fn update_account(ctx: Context<UpdateAccount>, pubkey_a: Pubkey, pubkey_b: P
 Trong Pinocchio, cùng một pattern validation được áp dụng:
 
 ```rust
-if self.accounts.program_account_1.key() == self.accounts.program_account_2.key() {
+if pubkey_eq(self.accounts.program_account_1.key(), self.accounts.program_account_2.key()) {
     return Err(ProgramError::InvalidArgument)
 }
 ```

--- a/src/app/content/courses/program-security/duplicate-mutable-accounts/zh-CN.mdx
+++ b/src/app/content/courses/program-security/duplicate-mutable-accounts/zh-CN.mdx
@@ -74,7 +74,7 @@ pub fn update_account(ctx: Context<UpdateAccount>, pubkey_a: Pubkey, pubkey_b: P
 在 Pinocchio 中，同样的验证模式适用：
 
 ```rust
-if self.accounts.program_account_1.key() == ctx.accounts.program_account_2.key() {
+if pubkey_eq(self.accounts.program_account_1.key(), self.accounts.program_account_2.key()) {
     return Err(ProgramError::InvalidArgument)
 }
 ```

--- a/src/app/content/courses/program-security/duplicate-mutable-accounts/zh-HK.mdx
+++ b/src/app/content/courses/program-security/duplicate-mutable-accounts/zh-HK.mdx
@@ -74,7 +74,7 @@ pub fn update_account(ctx: Context<UpdateAccount>, pubkey_a: Pubkey, pubkey_b: P
 在 Pinocchio 中，適用相同的驗證模式：
 
 ```rust
-if self.accounts.program_account_1.key() == self.accounts.program_account_2.key() {
+if pubkey_eq(self.accounts.program_account_1.key(), self.accounts.program_account_2.key()) {
     return Err(ProgramError::InvalidArgument)
 }
 ```


### PR DESCRIPTION
### Problem

`pinocchio` content uses not recommended way of comparison `Pubkey`s

### Solution

actualize content to use https://github.com/anza-xyz/pinocchio/pull/248 because it was published in [v0.9.2](https://github.com/anza-xyz/pinocchio/releases/tag/pinocchio%40v0.9.2)

cc @dhl 