### PR TITLE
fix: actualize instruction introspection for pinocchio

### DIFF
--- a/src/app/content/courses/instruction-introspection/introspection-with-pinocchio/de.mdx
+++ b/src/app/content/courses/instruction-introspection/introspection-with-pinocchio/de.mdx
@@ -9,10 +9,7 @@ Mit Hilfe von [Orion](https://x.com/BasedOrion_) haben wir eine Reihe von Hilfsf
 Aus diesem Grund können wir *Instruktions-Introspektion* in Pinocchio verwenden, ohne externe Crates zu installieren, und können auf alle benötigten Informationen zugreifen, indem wir diese Funktionen importieren:
 
 ```rust
-use pinocchio::sysvars::instructions::{
-    load_current_index_checked, 
-    load_instruction_at_checked
-}; 
+use pinocchio::sysvars::instructions::Instructions; 
 ```
 
 <ArticleSection name="Wie man Introspektion verwendet" id="how-to-use-introspection" level="h2" />
@@ -22,14 +19,15 @@ Wie bereits erwähnt, deserialisiert die Instruktions-Introspektion einfach die 
 Wir beginnen mit der Überprüfung des aktuellen Index. Dies können wir mit der Funktion `load_current_index_checked` tun, wie folgt:
 
 ```rust
-let index = load_current_index_checked(&self.accounts.sysvar_instructions)?;
+let instruction_sysvar = unsafe { Instructions::new_unchecked(&self.accounts.sysvar_instructions.try_borrow_data()?) };
+let index = instruction_sysvar.load_current_index();
 ```
 
 Danach können wir eine Instruktion an einem relativen Index mit `load_instruction_at_checked` überprüfen. Diesmal überprüfen wir die Instruktion, die unmittelbar auf diejenige folgt, die die Introspektion durchführt, wie folgt:
 
 ```rust
 // We load the next instruction, which is the one we want to check for the correct input.
-let instruction = load_instruction_at_checked(index as usize + 1, &self.accounts.sysvar_instructions)?;
+let instruction = instruction_sysvar.load_instruction_at(index as usize + 1)?;
 ```
 
 Bevor wir zum nächsten Schritt übergehen, sollten wir uns fragen, welche Informationen wesentlich sind, um einen böswilligen Angriff zu verhindern.

--- a/src/app/content/courses/instruction-introspection/introspection-with-pinocchio/en.mdx
+++ b/src/app/content/courses/instruction-introspection/introspection-with-pinocchio/en.mdx
@@ -10,10 +10,7 @@ implementation but made the `Instruction` sysvar — one of the most expensive s
 For this reason, we can use *Instruction Introspection* in Pinocchio without installing any external crates and can access all the information we need by importing these functions:
 
 ```rust
-use pinocchio::sysvars::instructions::{
-    load_current_index_checked, 
-    load_instruction_at_checked
-}; 
+use pinocchio::sysvars::instructions::Instructions;
 ```
 
 <ArticleSection name="How to use Introspection" id="how-to-use-introspection" level="h2" />
@@ -23,14 +20,15 @@ As mentioned previously, Instruction Introspection simply deserializes the data 
 We start by checking the current index. We can do this by using the `load_current_index_checked` function, like so:
 
 ```rust
-let index = load_current_index_checked(&self.accounts.sysvar_instructions)?;
+let instruction_sysvar = unsafe { Instructions::new_unchecked(&self.accounts.sysvar_instructions.try_borrow_data()?) };
+let index = instruction_sysvar.load_current_index();
 ```
 
 After this, we can check an instruction at a relative index using `load_instruction_at_checked`. This time, we'll check the instruction immediately following the one performing the introspection, like so:
 
 ```rust
 // We load the next instruction, which is the one we want to check for the correct input.
-let instruction = load_instruction_at_checked(index as usize + 1, &self.accounts.sysvar_instructions)?;
+let instruction = instruction_sysvar.load_instruction_at(index as usize + 1)?;
 ```
 
 Before going to the next step, we should ask ourselves what information is essential to prevent a malicious attack.

--- a/src/app/content/courses/instruction-introspection/introspection-with-pinocchio/fr.mdx
+++ b/src/app/content/courses/instruction-introspection/introspection-with-pinocchio/fr.mdx
@@ -9,10 +9,7 @@ Avec l'aide d'[Orion](https://x.com/BasedOrion_), nous avons créé un ensemble 
 Pour cette raison, nous pouvons utiliser l'*introspection des instructions* dans Pinocchio sans installer de crates externes et accéder à toutes les informations dont nous avons besoin en important ces fonctions :
 
 ```rust
-use pinocchio::sysvars::instructions::{
-    load_current_index_checked, 
-    load_instruction_at_checked
-}; 
+use pinocchio::sysvars::instructions::Instructions; 
 ```
 
 <ArticleSection name="Comment utiliser l'Introspection" id="how-to-use-introspection" level="h2" />
@@ -22,14 +19,15 @@ Comme mentionné précédemment, l'Introspection des Instructions désérialise 
 Nous commençons par vérifier l'index actuel. Nous pouvons le faire en utilisant la fonction `load_current_index_checked` comme ceci :
 
 ```rust
-let index = load_current_index_checked(&self.accounts.sysvar_instructions)?;
+let instruction_sysvar = unsafe { Instructions::new_unchecked(&self.accounts.sysvar_instructions.try_borrow_data()?) };
+let index = instruction_sysvar.load_current_index();
 ```
 
 Après cela, nous pouvons vérifier une instruction à un index relatif à l'aide de `load_instruction_at_checked`. Cette fois-ci, nous allons vérifier l'instruction qui suit immédiatement celle qui effectue l'introspection, comme ceci :
 
 ```rust
 // We load the next instruction, which is the one we want to check for the correct input.
-let instruction = load_instruction_at_checked(index as usize + 1, &self.accounts.sysvar_instructions)?;
+let instruction = instruction_sysvar.load_instruction_at(index as usize + 1)?;
 ```
 
 Avant de passer à l'étape suivante, nous devons nous demander quelles informations sont essentielles pour prévenir une attaque malveillante.

--- a/src/app/content/courses/instruction-introspection/introspection-with-pinocchio/id.mdx
+++ b/src/app/content/courses/instruction-introspection/introspection-with-pinocchio/id.mdx
@@ -9,10 +9,7 @@ Dengan bantuan [Orion](https://x.com/BasedOrion_), kami membuat serangkaian help
 Untuk alasan ini, kita dapat menggunakan *Instruksi Introspeksi* di Pinocchio tanpa menginstal crate eksternal dan dapat mengakses semua informasi yang kita butuhkan dengan mengimpor fungsi-fungsi ini:
 
 ```rust
-use pinocchio::sysvars::instructions::{
-    load_current_index_checked, 
-    load_instruction_at_checked
-}; 
+use pinocchio::sysvars::instructions::Instructions;
 ```
 
 <ArticleSection name="Cara menggunakan Introspeksi" id="how-to-use-introspection" level="h2" />
@@ -22,14 +19,15 @@ Seperti yang disebutkan sebelumnya, Instruksi Introspeksi hanya mendeserialkan d
 Kita mulai dengan memeriksa indeks saat ini. Kita dapat melakukan ini dengan menggunakan fungsi `load_current_index_checked`, seperti ini:
 
 ```rust
-let index = load_current_index_checked(&self.accounts.sysvar_instructions)?;
+let instruction_sysvar = unsafe { Instructions::new_unchecked(&self.accounts.sysvar_instructions.try_borrow_data()?) };
+let index = instruction_sysvar.load_current_index();
 ```
 
 Setelah ini, kita dapat memeriksa instruksi pada indeks relatif menggunakan `load_instruction_at_checked`. Kali ini, kita akan memeriksa instruksi yang langsung mengikuti instruksi yang melakukan introspeksi, seperti ini:
 
 ```rust
 // We load the next instruction, which is the one we want to check for the correct input.
-let instruction = load_instruction_at_checked(index as usize + 1, &self.accounts.sysvar_instructions)?;
+let instruction = instruction_sysvar.load_instruction_at(index as usize + 1)?;
 ```
 
 Sebelum melanjutkan ke langkah berikutnya, kita harus bertanya pada diri sendiri informasi apa yang penting untuk mencegah serangan berbahaya.

--- a/src/app/content/courses/instruction-introspection/introspection-with-pinocchio/uk.mdx
+++ b/src/app/content/courses/instruction-introspection/introspection-with-pinocchio/uk.mdx
@@ -10,10 +10,7 @@ Pinocchio використовує інші типи, ніж крейт `solana_
 З цієї причини ми можемо використовувати *Інтроспекцію інструкцій* у Pinocchio без встановлення зовнішніх крейтів і отримувати доступ до всієї необхідної інформації, імпортуючи ці функції:
 
 ```rust
-use pinocchio::sysvars::instructions::{
-    load_current_index_checked, 
-    load_instruction_at_checked
-}; 
+use pinocchio::sysvars::instructions::Instructions;
 ```
 
 <ArticleSection name="Як використовувати інтроспекцію" id="how-to-use-introspection" level="h2" />
@@ -23,14 +20,15 @@ use pinocchio::sysvars::instructions::{
 Ми починаємо з перевірки поточного індексу. Ми можемо зробити це за допомогою функції `load_current_index_checked`, ось так:
 
 ```rust
-let index = load_current_index_checked(&self.accounts.sysvar_instructions)?;
+let instruction_sysvar = unsafe { Instructions::new_unchecked(&self.accounts.sysvar_instructions.try_borrow_data()?) };
+let index = instruction_sysvar.load_current_index();
 ```
 
 Після цього ми можемо перевірити інструкцію за відносним індексом, використовуючи `load_instruction_at_checked`. Цього разу ми перевіримо інструкцію, яка безпосередньо слідує за тією, що виконує інтроспекцію, ось так:
 
 ```rust
 // We load the next instruction, which is the one we want to check for the correct input.
-let instruction = load_instruction_at_checked(index as usize + 1, &self.accounts.sysvar_instructions)?;
+let instruction = instruction_sysvar.load_instruction_at(index as usize + 1)?;
 ```
 
 Перш ніж перейти до наступного кроку, ми повинні запитати себе, яка інформація є важливою для запобігання зловмисній атаці.

--- a/src/app/content/courses/instruction-introspection/introspection-with-pinocchio/vi.mdx
+++ b/src/app/content/courses/instruction-introspection/introspection-with-pinocchio/vi.mdx
@@ -9,10 +9,7 @@ Với sự giúp đỡ của [Orion](https://x.com/BasedOrion_), chúng ta đã 
 Vì lý do này, chúng ta có thể sử dụng *Instruction Introspection* trong Pinocchio mà không cần cài đặt bất kỳ crate bên ngoài nào và có thể truy cập tất cả thông tin chúng ta cần bằng cách import các hàm này:
 
 ```rust
-use pinocchio::sysvars::instructions::{
-    load_current_index_checked, 
-    load_instruction_at_checked
-}; 
+use pinocchio::sysvars::instructions::Instructions;
 ```
 
 <ArticleSection name="Cách sử dụng Introspection" id="how-to-use-introspection" level="h2" />
@@ -22,14 +19,15 @@ Như đã đề cập trước đó, Instruction Introspection đơn giản ch�
 Chúng ta bắt đầu bằng cách kiểm tra chỉ số hiện tại. Chúng ta có thể làm điều này bằng cách sử dụng hàm `load_current_index_checked`, như sau:
 
 ```rust
-let index = load_current_index_checked(&self.accounts.sysvar_instructions)?;
+let instruction_sysvar = unsafe { Instructions::new_unchecked(&self.accounts.sysvar_instructions.try_borrow_data()?) };
+let index = instruction_sysvar.load_current_index();
 ```
 
 Sau đó, chúng ta có thể kiểm tra một instruction tại chỉ số tương đối bằng `load_instruction_at_checked`. Lần này, chúng ta sẽ kiểm tra instruction ngay sau instruction đang thực hiện introspection, như sau:
 
 ```rust
 // We load the next instruction, which is the one we want to check for the correct input.
-let instruction = load_instruction_at_checked(index as usize + 1, &self.accounts.sysvar_instructions)?;
+let instruction = instruction_sysvar.load_instruction_at(index as usize + 1)?;
 ```
 
 Trước khi chuyển sang bước tiếp theo, chúng ta nên tự hỏi thông tin nào là cần thiết để ngăn chặn một cuộc tấn công độc hại.

--- a/src/app/content/courses/instruction-introspection/introspection-with-pinocchio/zh-CN.mdx
+++ b/src/app/content/courses/instruction-introspection/introspection-with-pinocchio/zh-CN.mdx
@@ -9,10 +9,7 @@ Pinocchio 使用的类型与 `solana_program` crate 不同。这意味着我们�
 因此，我们可以在 Pinocchio 中使用*指令内省*，无需安装任何外部 crate，并且可以通过导入这些函数访问我们所需的所有信息：
 
 ```rust
-use pinocchio::sysvars::instructions::{
-    load_current_index_checked, 
-    load_instruction_at_checked
-}; 
+use pinocchio::sysvars::instructions::Instructions;
 ```
 
 <ArticleSection name="如何使用内省" id="how-to-use-introspection" level="h2" />
@@ -22,14 +19,15 @@ use pinocchio::sysvars::instructions::{
 我们从检查当前索引开始。可以通过使用 `load_current_index_checked` 函数来实现，如下所示：
 
 ```rust
-let index = load_current_index_checked(&self.accounts.sysvar_instructions)?;
+let instruction_sysvar = unsafe { Instructions::new_unchecked(&self.accounts.sysvar_instructions.try_borrow_data()?) };
+let index = instruction_sysvar.load_current_index();
 ```
 
 之后，我们可以使用 `load_instruction_at_checked` 检查相对索引处的指令。这次，我们将检查紧随执行内省的指令之后的指令，如下所示：
 
 ```rust
 // We load the next instruction, which is the one we want to check for the correct input.
-let instruction = load_instruction_at_checked(index as usize + 1, &self.accounts.sysvar_instructions)?;
+let instruction = instruction_sysvar.load_instruction_at(index as usize + 1)?;
 ```
 
 在进入下一步之前，我们应该问自己哪些信息对于防止恶意攻击是必不可少的。

--- a/src/app/content/courses/instruction-introspection/introspection-with-pinocchio/zh-HK.mdx
+++ b/src/app/content/courses/instruction-introspection/introspection-with-pinocchio/zh-HK.mdx
@@ -9,10 +9,7 @@ Pinocchio 使用的類型與 `solana_program` crate 不同。這意味著我們�
 因此，我們可以在 Pinocchio 中使用 *指令內省*，而無需安裝任何外部 crate，並且可以通過導入這些函數來獲取我們所需的所有信息：
 
 ```rust
-use pinocchio::sysvars::instructions::{
-    load_current_index_checked, 
-    load_instruction_at_checked
-}; 
+use pinocchio::sysvars::instructions::Instructions; 
 ```
 
 <ArticleSection name="如何使用內省" id="how-to-use-introspection" level="h2" />
@@ -22,14 +19,15 @@ use pinocchio::sysvars::instructions::{
 我們首先檢查當前索引。我們可以通過使用 `load_current_index_checked` 函數來完成，如下所示：
 
 ```rust
-let index = load_current_index_checked(&self.accounts.sysvar_instructions)?;
+let instruction_sysvar = unsafe { Instructions::new_unchecked(&self.accounts.sysvar_instructions.try_borrow_data()?) };
+let index = instruction_sysvar.load_current_index();
 ```
 
 之後，我們可以使用 `load_instruction_at_checked` 在相對索引處檢查一條指令。這次，我們將檢查執行內省的指令之後的那條指令，如下所示：
 
 ```rust
 // We load the next instruction, which is the one we want to check for the correct input.
-let instruction = load_instruction_at_checked(index as usize + 1, &self.accounts.sysvar_instructions)?;
+let instruction = instruction_sysvar.load_instruction_at(index as usize + 1)?;
 ```
 
 在進入下一步之前，我們應該問自己，哪些信息對於防止惡意攻擊是必不可少的。


### PR DESCRIPTION
### Problem

**pinocchio**s section of `instruction-introspection` course has obsolete information

### Solution

actualize the section (imports, api, etc)

cc @dhl 