### PR TITLE
fix: version of thiserror crate should be 2.0

### DIFF
--- a/src/app/content/courses/pinocchio-for-dummies/pinocchio-errors/de.mdx
+++ b/src/app/content/courses/pinocchio-for-dummies/pinocchio-errors/de.mdx
@@ -16,7 +16,7 @@ Um thiserror in einem Pinocchio-Programm zu verwenden, fügen Sie es zu Ihrer `C
 
 ```
 [dependencies]
-thiserror = { version = "1.0", default-features = false }
+thiserror = { version = "2.0", default-features = false }
 ```
 
 Hier ist, wie Sie einen benutzerdefinierten Fehlertyp für Ihr Pinocchio-Programm definieren können:

--- a/src/app/content/courses/pinocchio-for-dummies/pinocchio-errors/en.mdx
+++ b/src/app/content/courses/pinocchio-for-dummies/pinocchio-errors/en.mdx
@@ -16,7 +16,7 @@ To use thiserror in a Pinocchio program, add it to your `Cargo.toml` like this:
 
 ```
 [dependencies]
-thiserror = { version = "1.0", default-features = false }
+thiserror = { version = "2.0", default-features = false }
 ```
 
 Here’s how you can define a custom error type for your Pinocchio program:

--- a/src/app/content/courses/pinocchio-for-dummies/pinocchio-errors/fr.mdx
+++ b/src/app/content/courses/pinocchio-for-dummies/pinocchio-errors/fr.mdx
@@ -16,7 +16,7 @@ Pour utiliser `thiserror` dans un programme Pinocchio, ajoutez-le à votre fichi
 
 ```
 [dependencies]
-thiserror = { version = "1.0", default-features = false }
+thiserror = { version = "2.0", default-features = false }
 ```
 
 Voici comment définir un type d'erreur personnalisé pour votre programme Pinocchio :

--- a/src/app/content/courses/pinocchio-for-dummies/pinocchio-errors/id.mdx
+++ b/src/app/content/courses/pinocchio-for-dummies/pinocchio-errors/id.mdx
@@ -16,7 +16,7 @@ Untuk menggunakan thiserror dalam program Pinocchio, tambahkan ke `Cargo.toml` A
 
 ```
 [dependencies]
-thiserror = { version = "1.0", default-features = false }
+thiserror = { version = "2.0", default-features = false }
 ```
 
 Berikut cara Anda dapat mendefinisikan jenis error kustom untuk program Pinocchio Anda:

--- a/src/app/content/courses/pinocchio-for-dummies/pinocchio-errors/uk.mdx
+++ b/src/app/content/courses/pinocchio-for-dummies/pinocchio-errors/uk.mdx
@@ -16,7 +16,7 @@ import { ArticleSection } from "../../../../components/ArticleSection/ArticleSec
 
 ```
 [dependencies]
-thiserror = { version = "1.0", default-features = false }
+thiserror = { version = "2.0", default-features = false }
 ```
 
 Ось як ви можете визначити користувацький тип помилки для вашої програми Pinocchio:

--- a/src/app/content/courses/pinocchio-for-dummies/pinocchio-errors/vi.mdx
+++ b/src/app/content/courses/pinocchio-for-dummies/pinocchio-errors/vi.mdx
@@ -16,7 +16,7 @@ Khi định nghĩa các kiểu error tùy chỉnh trong Rust, bạn có một s�
 
 ```
 [dependencies]
-thiserror = { version = "1.0", default-features = false }
+thiserror = { version = "2.0", default-features = false }
 ```
 
 Here’s how you can define a custom error type for your Pinocchio program:

--- a/src/app/content/courses/pinocchio-for-dummies/pinocchio-errors/zh-CN.mdx
+++ b/src/app/content/courses/pinocchio-for-dummies/pinocchio-errors/zh-CN.mdx
@@ -16,7 +16,7 @@ import { ArticleSection } from "../../../../components/ArticleSection/ArticleSec
 
 ```
 [dependencies]
-thiserror = { version = "1.0", default-features = false }
+thiserror = { version = "2.0", default-features = false }
 ```
 
 以下是为您的 Pinocchio 程序定义自定义错误类型的方法：

--- a/src/app/content/courses/pinocchio-for-dummies/pinocchio-errors/zh-HK.mdx
+++ b/src/app/content/courses/pinocchio-for-dummies/pinocchio-errors/zh-HK.mdx
@@ -16,7 +16,7 @@ import { ArticleSection } from "../../../../components/ArticleSection/ArticleSec
 
 ```
 [dependencies]
-thiserror = { version = "1.0", default-features = false }
+thiserror = { version = "2.0", default-features = false }
 ```
 
 以下是如何為您的 Pinocchio 程式定義自訂錯誤類型：


### PR DESCRIPTION
The no_std feature is supported starting from version 2.0 of the thiserror crate. Therefore, the minimum required version should be 2.0 or higher.

https://github.com/dtolnay/thiserror/releases/tag/2.0.0 
