### PR TITLE
Update Pinocchio Escrow lessons for p-token batching

### DIFF
--- a/src/app/content/challenges/pinocchio-escrow/de/pages/make.mdx
+++ b/src/app/content/challenges/pinocchio-escrow/de/pages/make.mdx
@@ -188,12 +188,13 @@ impl<'a> Make<'a> {
     );
 
     // Transfer tokens to vault
-    Transfer {
-      from: self.accounts.maker_ata_a,
-      to: self.accounts.vault,
-      authority: self.accounts.maker,
-      amount: self.instruction_data.amount
-    }.invoke()?;
+    Transfer::new(
+      self.accounts.maker_ata_a,
+      self.accounts.vault,
+      self.accounts.maker,
+      self.instruction_data.amount,
+    )
+    .invoke()?;
 
     Ok(())
   }

--- a/src/app/content/challenges/pinocchio-escrow/de/pages/take.mdx
+++ b/src/app/content/challenges/pinocchio-escrow/de/pages/take.mdx
@@ -2,9 +2,12 @@
 
 Die `take` Anweisung schließt den Tausch ab:
 
-- Schließt den Escrow-Datensatz und sendet die Rent-Lamports zurück an den Ersteller.
-- Überträgt Token A vom Tresor zum Nehmer und schließt dann den Tresor.
+- Überträgt Token A vom Tresor zum Nehmer.
+- Schließt das nun leere Vault-Token-Konto.
 - Überträgt die vereinbarte Menge von Token B vom Nehmer zum Ersteller.
+- Schließt das Escrow-Programmkonto.
+
+Da `p-token` bereits auf Mainnet live ist, ist dies ein guter Ort, um den aktuellen Batch-Flow zu verwenden. Wir können beide Token-Transfers und das Schließen des Vaults in einen einzigen `Batch` packen.
 
 <ArticleSection name="Required Accounts" id="required-accounts" level="h2" />
 
@@ -20,7 +23,7 @@ Nachfolgend sind die Konten aufgeführt, die der Kontext benötigt:
 - taker_ata_b: das zugehörige Token-Konto im Besitz des Nehmers für mint_b. Muss veränderbar sein
 - maker_ata_b: das zugehörige Token-Konto im Besitz des Erstellers für mint_b. Muss veränderbar sein
 - system_program: das System-Programm. Muss ausführbar sein
-- token_program: das Token-Programm. Muss ausführbar sein
+- token_program: das Token-Programm. Da `p-token` auf Mainnet live ist, unterstützt dieses Konto auch das Batching der Token-Transfers in dieser Anweisung. Muss ausführbar sein
 
 Und wir führen folgende Prüfungen daran durch:
 
@@ -122,9 +125,12 @@ impl<'a> TryFrom<&'a [AccountInfo]> for Take<'a> {
 
 Wir können uns jetzt auf die eigentliche Logik konzentrieren, die:
 
-- Die Token vom `taker_ata_b` zum `maker_ata_b` überträgt.
 - Die Token vom `vault` zum `taker_ata_a` überträgt.
-- Das nun leere `vault` schließt und die Miete vom Konto abhebt.
+- Das nun leere `vault` Token-Konto schließt und die Miete vom Konto abhebt.
+- Die Token vom `taker_ata_b` zum `maker_ata_b` überträgt.
+- Das `escrow` Programmkonto schließt, sobald der Tausch abgeschlossen ist.
+
+Die wichtigste Änderung ist, dass wir beide Token-Transfers und das Schließen des Vaults batchen und das Token-Programm nur einmal aufrufen können. Die Escrow-PDA muss weiterhin signieren, weil sie sowohl den Transfer aus dem Vault als auch `CloseAccount` auf diesem Token-Konto autorisiert. Daher endet der Batch mit `batch.invoke_signed(&[signer.clone()])?;`. Danach schließen wir das `escrow` weiterhin mit `ProgramAccount::close`, weil es ein programmgesteuertes Konto ist:
 
 ```rust
 impl<'a> Take<'a> {
@@ -152,30 +158,34 @@ impl<'a> Take<'a> {
 
     let amount = TokenAccount::from_account_info(self.accounts.vault)?.amount();
 
-    // Transfer from the Vault to the Taker
-    Transfer {
-      from: self.accounts.vault,
-      to: self.accounts.taker_ata_a,
-      authority: self.accounts.escrow,
+    let mut batch = Batch::default();
+
+    Transfer::new(
+      self.accounts.vault,
+      self.accounts.taker_ata_a,
+      self.accounts.escrow,
       amount,
-    }.invoke_signed(&[signer.clone()])?;
+    )
+    .into_batch(&mut batch)?;
 
-    // Close the Vault
-    CloseAccount {
-      account: self.accounts.vault,
-      destination: self.accounts.maker,
-      authority: self.accounts.escrow,
-    }.invoke_signed(&[signer.clone()])?;
+    CloseAccount::new(
+      self.accounts.vault,
+      self.accounts.maker,
+      self.accounts.escrow,
+    )
+    .into_batch(&mut batch)?;
 
-    // Transfer from the Taker to the Maker
-    Transfer {
-      from: self.accounts.taker_ata_b,
-      to: self.accounts.maker_ata_b,
-      authority: self.accounts.taker,
-      amount: escrow.receive,
-    }.invoke()?;
+    Transfer::new(
+      self.accounts.taker_ata_b,
+      self.accounts.maker_ata_b,
+      self.accounts.taker,
+      escrow.receive,
+    )
+    .into_batch(&mut batch)?;
 
-    // Close the Escrow
+    batch.invoke_signed(&[signer.clone()])?;
+
+    // Close the Escrow program account
     drop(data);
     ProgramAccount::close(self.accounts.escrow, self.accounts.taker)?;
 

--- a/src/app/content/challenges/pinocchio-escrow/de/pages/take.mdx
+++ b/src/app/content/challenges/pinocchio-escrow/de/pages/take.mdx
@@ -7,8 +7,6 @@ Die `take` Anweisung schließt den Tausch ab:
 - Überträgt die vereinbarte Menge von Token B vom Nehmer zum Ersteller.
 - Schließt das Escrow-Programmkonto.
 
-Da `p-token` bereits auf Mainnet live ist, ist dies ein guter Ort, um den aktuellen Batch-Flow zu verwenden. Wir können beide Token-Transfers und das Schließen des Vaults in einen einzigen `Batch` packen.
-
 <ArticleSection name="Required Accounts" id="required-accounts" level="h2" />
 
 Nachfolgend sind die Konten aufgeführt, die der Kontext benötigt:
@@ -23,7 +21,7 @@ Nachfolgend sind die Konten aufgeführt, die der Kontext benötigt:
 - taker_ata_b: das zugehörige Token-Konto im Besitz des Nehmers für mint_b. Muss veränderbar sein
 - maker_ata_b: das zugehörige Token-Konto im Besitz des Erstellers für mint_b. Muss veränderbar sein
 - system_program: das System-Programm. Muss ausführbar sein
-- token_program: das Token-Programm. Da `p-token` auf Mainnet live ist, unterstützt dieses Konto auch das Batching der Token-Transfers in dieser Anweisung. Muss ausführbar sein
+- token_program: das Token-Programm. Muss ausführbar sein
 
 Und wir führen folgende Prüfungen daran durch:
 
@@ -130,11 +128,14 @@ Wir können uns jetzt auf die eigentliche Logik konzentrieren, die:
 - Die Token vom `taker_ata_b` zum `maker_ata_b` überträgt.
 - Das `escrow` Programmkonto schließt, sobald der Tausch abgeschlossen ist.
 
-Die wichtigste Änderung ist, dass wir beide Token-Transfers und das Schließen des Vaults batchen und das Token-Programm nur einmal aufrufen können. Die Escrow-PDA muss weiterhin signieren, weil sie sowohl den Transfer aus dem Vault als auch `CloseAccount` auf diesem Token-Konto autorisiert. Daher endet der Batch mit `batch.invoke_signed(&[signer.clone()])?;`. Danach schließen wir das `escrow` weiterhin mit `ProgramAccount::close`, weil es ein programmgesteuertes Konto ist:
+Anstatt den Tausch mit drei separaten Token-CPI-Aufrufen abzuschließen, können wir die Batch-Instruktion in [`p-token`](https://solana.com/upgrades/p-token) nutzen, um alle Token-Operationen effizient in einem einzigen CPI-Aufruf auszuführen.
 
 ```rust
 impl<'a> Take<'a> {
   pub const DISCRIMINATOR: &'a u8 = &1;
+
+  const MAX_ACCOUNTS_LEN: usize = Transfer::MAX_ACCOUNTS_LEN * 2 + CloseAccount::MAX_ACCOUNTS_LEN;
+  const MAX_DATA_LEN: usize = Batch::header_data_len(3) + Transfer::DATA_LEN * 2 + CloseAccount::DATA_LEN;
 
   pub fn process(&mut self) -> ProgramResult {
     let data = self.accounts.escrow.try_borrow_data()?;
@@ -158,7 +159,8 @@ impl<'a> Take<'a> {
 
     let amount = TokenAccount::from_account_info(self.accounts.vault)?.amount();
 
-    let mut batch = Batch::default();
+    let batch_state = BatchState::new(Self::MAX_ACCOUNTS_LEN, Self::MAX_DATA_LEN);
+    let mut batch = batch_state.as_batch()?;
 
     Transfer::new(
       self.accounts.vault,
@@ -183,7 +185,7 @@ impl<'a> Take<'a> {
     )
     .into_batch(&mut batch)?;
 
-    batch.invoke_signed(&[signer.clone()])?;
+    batch.invoke_signed(&[signer])?;
 
     // Close the Escrow program account
     drop(data);
@@ -193,3 +195,5 @@ impl<'a> Take<'a> {
   }
 }
 ```
+
+> Stelle sicher, dass `pinocchio-token` mindestens Version `0.6.0` hat, um [p-token](https://solana.com/upgrades/p-token) Batch-Operationen zu unterstützen.

--- a/src/app/content/challenges/pinocchio-escrow/en/pages/make.mdx
+++ b/src/app/content/challenges/pinocchio-escrow/en/pages/make.mdx
@@ -188,12 +188,13 @@ impl<'a> Make<'a> {
     );
 
     // Transfer tokens to vault
-    Transfer {
-      from: self.accounts.maker_ata_a,
-      to: self.accounts.vault,
-      authority: self.accounts.maker,
-      amount: self.instruction_data.amount
-    }.invoke()?;
+    Transfer::new(
+      self.accounts.maker_ata_a,
+      self.accounts.vault,
+      self.accounts.maker,
+      self.instruction_data.amount,
+    )
+    .invoke()?;
 
     Ok(())
   }

--- a/src/app/content/challenges/pinocchio-escrow/en/pages/take.mdx
+++ b/src/app/content/challenges/pinocchio-escrow/en/pages/take.mdx
@@ -2,9 +2,12 @@
 
 The `take` instruction finalizes the swap:
 
-- Close the escrow record, sending its rent lamports back to the maker.
-- Move Token A from the vault to the taker, then close the vault.
+- Move Token A from the vault to the taker.
+- Close the now empty vault token account.
 - Move the agreed amount of Token B from the taker to the maker.
+- Close the escrow program account.
+
+With `p-token` live on mainnet, this is a good place to use the current batch flow. We can queue both token transfers and the vault close into a single `Batch`.
 
 <ArticleSection name="Required Accounts" id="required-accounts" level="h2" />
 
@@ -20,7 +23,7 @@ Below are the accounts the context needs:
 - taker_ata_b: the associated token account owned by the taker for mint_b. Must be mutable
 - maker_ata_b: the associated token account owned by the maker for mint_b. Must be mutable
 - system_program: the system program. Must be executable
-- token_program: the token program. Must be executable
+- token_program: the token program. With `p-token` live on mainnet, this same account also supports batching the token transfers in this instruction. Must be executable
 
 And we perform these checks on it:
 
@@ -122,9 +125,12 @@ impl<'a> TryFrom<&'a [AccountInfo]> for Take<'a> {
 
 We can now focus on the logic itself that will:
 
-- Transfer the tokens from the `taker_ata_b` to the `maker_ata_b`.
 - Transfer the tokens from the `vault` to the `taker_ata_a`.
-- Close the now empty `vault` and withdraw the rent from the account.
+- Close the now empty `vault` token account and withdraw its rent.
+- Transfer the tokens from the `taker_ata_b` to the `maker_ata_b`.
+- Close the `escrow` program account once the swap is complete.
+
+The main change is that we can batch both token transfers and the vault close, then invoke the token program once. The escrow PDA still needs to sign because it authorizes both the transfer out of the vault and the `CloseAccount` on that token account, so the batch ends with `batch.invoke_signed(&[signer.clone()])?;`. After that, we still close the `escrow` with `ProgramAccount::close` because it is a program-owned account:
 
 ```rust
 impl<'a> Take<'a> {
@@ -152,30 +158,34 @@ impl<'a> Take<'a> {
 
     let amount = TokenAccount::from_account_info(self.accounts.vault)?.amount();
 
-    // Transfer from the Vault to the Taker
-    Transfer {
-      from: self.accounts.vault,
-      to: self.accounts.taker_ata_a,
-      authority: self.accounts.escrow,
+    let mut batch = Batch::default();
+
+    Transfer::new(
+      self.accounts.vault,
+      self.accounts.taker_ata_a,
+      self.accounts.escrow,
       amount,
-    }.invoke_signed(&[signer.clone()])?;
+    )
+    .into_batch(&mut batch)?;
 
-    // Close the Vault
-    CloseAccount {
-      account: self.accounts.vault,
-      destination: self.accounts.maker,
-      authority: self.accounts.escrow,
-    }.invoke_signed(&[signer.clone()])?;
+    CloseAccount::new(
+      self.accounts.vault,
+      self.accounts.maker,
+      self.accounts.escrow,
+    )
+    .into_batch(&mut batch)?;
 
-    // Transfer from the Taker to the Maker
-    Transfer {
-      from: self.accounts.taker_ata_b,
-      to: self.accounts.maker_ata_b,
-      authority: self.accounts.taker,
-      amount: escrow.receive,
-    }.invoke()?;
+    Transfer::new(
+      self.accounts.taker_ata_b,
+      self.accounts.maker_ata_b,
+      self.accounts.taker,
+      escrow.receive,
+    )
+    .into_batch(&mut batch)?;
 
-    // Close the Escrow
+    batch.invoke_signed(&[signer.clone()])?;
+
+    // Close the Escrow program account
     drop(data);
     ProgramAccount::close(self.accounts.escrow, self.accounts.taker)?;
 

--- a/src/app/content/challenges/pinocchio-escrow/en/pages/take.mdx
+++ b/src/app/content/challenges/pinocchio-escrow/en/pages/take.mdx
@@ -7,8 +7,6 @@ The `take` instruction finalizes the swap:
 - Move the agreed amount of Token B from the taker to the maker.
 - Close the escrow program account.
 
-With `p-token` live on mainnet, this is a good place to use the current batch flow. We can queue both token transfers and the vault close into a single `Batch`.
-
 <ArticleSection name="Required Accounts" id="required-accounts" level="h2" />
 
 Below are the accounts the context needs:
@@ -23,7 +21,7 @@ Below are the accounts the context needs:
 - taker_ata_b: the associated token account owned by the taker for mint_b. Must be mutable
 - maker_ata_b: the associated token account owned by the maker for mint_b. Must be mutable
 - system_program: the system program. Must be executable
-- token_program: the token program. With `p-token` live on mainnet, this same account also supports batching the token transfers in this instruction. Must be executable
+- token_program: the token program. Must be executable
 
 And we perform these checks on it:
 
@@ -84,7 +82,7 @@ All the data that we need to perform the logic already lives in the Escrow accou
 
 We begin by initializing the required accounts in the `TryFrom` implementation, after we've deserialized the accounts.
 
-For this step, we ensure both the taker's Token A account and the maker's Token B account are initialized using the `AssociatedTokenAccount::init_if_needed` since we're not sure that they already exists
+For this step, we ensure both the taker's Token A account and the maker's Token B account are initialized using `AssociatedTokenAccount::init_if_needed` since we're not sure that they already exist.
 
 ```rust
 pub struct Take<'a> {
@@ -130,11 +128,14 @@ We can now focus on the logic itself that will:
 - Transfer the tokens from the `taker_ata_b` to the `maker_ata_b`.
 - Close the `escrow` program account once the swap is complete.
 
-The main change is that we can batch both token transfers and the vault close, then invoke the token program once. The escrow PDA still needs to sign because it authorizes both the transfer out of the vault and the `CloseAccount` on that token account, so the batch ends with `batch.invoke_signed(&[signer.clone()])?;`. After that, we still close the `escrow` with `ProgramAccount::close` because it is a program-owned account:
+Rather than doing three separate token CPI calls to finalize the swap, we can take advantage of the batch instruction in [`p-token`](https://solana.com/upgrades/p-token) to efficiently perform all the token operations in a single CPI call.
 
 ```rust
 impl<'a> Take<'a> {
   pub const DISCRIMINATOR: &'a u8 = &1;
+
+  const MAX_ACCOUNTS_LEN: usize = Transfer::MAX_ACCOUNTS_LEN * 2 + CloseAccount::MAX_ACCOUNTS_LEN;
+  const MAX_DATA_LEN: usize = Batch::header_data_len(3) + Transfer::DATA_LEN * 2 + CloseAccount::DATA_LEN;
 
   pub fn process(&mut self) -> ProgramResult {
     let data = self.accounts.escrow.try_borrow_data()?;
@@ -158,7 +159,8 @@ impl<'a> Take<'a> {
 
     let amount = TokenAccount::from_account_info(self.accounts.vault)?.amount();
 
-    let mut batch = Batch::default();
+    let batch_state = BatchState::new(Self::MAX_ACCOUNTS_LEN, Self::MAX_DATA_LEN);
+    let mut batch = batch_state.as_batch()?;
 
     Transfer::new(
       self.accounts.vault,
@@ -183,7 +185,7 @@ impl<'a> Take<'a> {
     )
     .into_batch(&mut batch)?;
 
-    batch.invoke_signed(&[signer.clone()])?;
+    batch.invoke_signed(&[signer])?;
 
     // Close the Escrow program account
     drop(data);
@@ -193,3 +195,5 @@ impl<'a> Take<'a> {
   }
 }
 ```
+
+> Make sure `pinocchio-token` is at least version `0.6.0` to support [p-token](https://solana.com/upgrades/p-token) batch operations.

--- a/src/app/content/challenges/pinocchio-escrow/fr/pages/make.mdx
+++ b/src/app/content/challenges/pinocchio-escrow/fr/pages/make.mdx
@@ -188,12 +188,13 @@ impl<'a> Make<'a> {
     );
 
     // Transfer tokens to vault
-    Transfer {
-      from: self.accounts.maker_ata_a,
-      to: self.accounts.vault,
-      authority: self.accounts.maker,
-      amount: self.instruction_data.amount
-    }.invoke()?;
+    Transfer::new(
+      self.accounts.maker_ata_a,
+      self.accounts.vault,
+      self.accounts.maker,
+      self.instruction_data.amount,
+    )
+    .invoke()?;
 
     Ok(())
   }

--- a/src/app/content/challenges/pinocchio-escrow/fr/pages/take.mdx
+++ b/src/app/content/challenges/pinocchio-escrow/fr/pages/take.mdx
@@ -2,9 +2,12 @@
 
 L'instruction `take` finalise l'échange :
 
-- Ferme le compte d'escrow en retournant la rente au créateur.
-- Transfére le Jeton A du coffre au preneur puis ferme le vault.
+- Transfére le Jeton A du vault au preneur.
+- Ferme le compte de jetons du vault désormais vide.
 - Transférer le montant convenu du Jeton B du preneur au créateur.
+- Ferme le compte de programme `escrow`.
+
+Avec `p-token` déjà live sur mainnet, c'est un bon endroit pour utiliser le flux de batch actuel. Nous pouvons mettre les deux transferts de jetons et la fermeture du vault dans un seul `Batch`.
 
 <ArticleSection name="Comptes Nécessaires" id="required-accounts" level="h2" />
 
@@ -20,7 +23,7 @@ Voici les comptes dont le contexte a besoin :
 - taker_ata_b: le compte de jetons associé appartenant au preneur pour le mint_b. Doit être mutable
 - maker_ata_b: le compte de jetons associé appartenant au créateur pour le mint_b. Doit être mutable
 - system_program: le programme système. Doit être executable
-- token_program: le programme de jeton. Doit être executable
+- token_program: le programme de jeton. Avec `p-token` live sur mainnet, ce même compte prend aussi en charge le batching des transferts de jetons dans cette instruction. Doit être executable
 
 Et nous effectuons ces vérifications :
 
@@ -122,9 +125,12 @@ impl<'a> TryFrom<&'a [AccountInfo]> for Take<'a> {
 
 Nous pouvons maintenant nous concentrer sur la logique elle-même :
 
-- Transférer les jetons de `taker_ata_b` vers `maker_ata_b`.
 - Transférer les jetons du `vault` vers `taker_ata_a`.
-- Fermer le `vault` désormais vide et récupérer la rente du compte.
+- Fermer le compte de jetons `vault` désormais vide et récupérer sa rente.
+- Transférer les jetons de `taker_ata_b` vers `maker_ata_b`.
+- Fermer le compte de programme `escrow` une fois l'échange terminé.
+
+Le principal changement est que nous pouvons batcher les deux transferts de jetons et la fermeture du vault, puis n'invoquer le programme de jetons qu'une seule fois. La PDA de l'escrow doit toujours signer, car elle autorise à la fois le transfert sortant depuis le vault et le `CloseAccount` sur ce compte de jetons. Le batch se termine donc par `batch.invoke_signed(&[signer.clone()])?;`. Ensuite, nous fermons toujours `escrow` avec `ProgramAccount::close`, car il s'agit d'un compte détenu par le programme :
 
 ```rust
 impl<'a> Take<'a> {
@@ -152,30 +158,34 @@ impl<'a> Take<'a> {
 
     let amount = TokenAccount::from_account_info(self.accounts.vault)?.amount();
 
-    // Transfer from the Vault to the Taker
-    Transfer {
-      from: self.accounts.vault,
-      to: self.accounts.taker_ata_a,
-      authority: self.accounts.escrow,
+    let mut batch = Batch::default();
+
+    Transfer::new(
+      self.accounts.vault,
+      self.accounts.taker_ata_a,
+      self.accounts.escrow,
       amount,
-    }.invoke_signed(&[signer.clone()])?;
+    )
+    .into_batch(&mut batch)?;
 
-    // Close the Vault
-    CloseAccount {
-      account: self.accounts.vault,
-      destination: self.accounts.maker,
-      authority: self.accounts.escrow,
-    }.invoke_signed(&[signer.clone()])?;
+    CloseAccount::new(
+      self.accounts.vault,
+      self.accounts.maker,
+      self.accounts.escrow,
+    )
+    .into_batch(&mut batch)?;
 
-    // Transfer from the Taker to the Maker
-    Transfer {
-      from: self.accounts.taker_ata_b,
-      to: self.accounts.maker_ata_b,
-      authority: self.accounts.taker,
-      amount: escrow.receive,
-    }.invoke()?;
+    Transfer::new(
+      self.accounts.taker_ata_b,
+      self.accounts.maker_ata_b,
+      self.accounts.taker,
+      escrow.receive,
+    )
+    .into_batch(&mut batch)?;
 
-    // Close the Escrow
+    batch.invoke_signed(&[signer.clone()])?;
+
+    // Close the Escrow program account
     drop(data);
     ProgramAccount::close(self.accounts.escrow, self.accounts.taker)?;
 

--- a/src/app/content/challenges/pinocchio-escrow/fr/pages/take.mdx
+++ b/src/app/content/challenges/pinocchio-escrow/fr/pages/take.mdx
@@ -7,8 +7,6 @@ L'instruction `take` finalise l'échange :
 - Transférer le montant convenu du Jeton B du preneur au créateur.
 - Ferme le compte de programme `escrow`.
 
-Avec `p-token` déjà live sur mainnet, c'est un bon endroit pour utiliser le flux de batch actuel. Nous pouvons mettre les deux transferts de jetons et la fermeture du vault dans un seul `Batch`.
-
 <ArticleSection name="Comptes Nécessaires" id="required-accounts" level="h2" />
 
 Voici les comptes dont le contexte a besoin :
@@ -23,7 +21,7 @@ Voici les comptes dont le contexte a besoin :
 - taker_ata_b: le compte de jetons associé appartenant au preneur pour le mint_b. Doit être mutable
 - maker_ata_b: le compte de jetons associé appartenant au créateur pour le mint_b. Doit être mutable
 - system_program: le programme système. Doit être executable
-- token_program: le programme de jeton. Avec `p-token` live sur mainnet, ce même compte prend aussi en charge le batching des transferts de jetons dans cette instruction. Doit être executable
+- token_program: le programme de jeton. Doit être executable
 
 Et nous effectuons ces vérifications :
 
@@ -130,11 +128,14 @@ Nous pouvons maintenant nous concentrer sur la logique elle-même :
 - Transférer les jetons de `taker_ata_b` vers `maker_ata_b`.
 - Fermer le compte de programme `escrow` une fois l'échange terminé.
 
-Le principal changement est que nous pouvons batcher les deux transferts de jetons et la fermeture du vault, puis n'invoquer le programme de jetons qu'une seule fois. La PDA de l'escrow doit toujours signer, car elle autorise à la fois le transfert sortant depuis le vault et le `CloseAccount` sur ce compte de jetons. Le batch se termine donc par `batch.invoke_signed(&[signer.clone()])?;`. Ensuite, nous fermons toujours `escrow` avec `ProgramAccount::close`, car il s'agit d'un compte détenu par le programme :
+Plutôt que d'effectuer trois appels CPI de jetons séparés pour finaliser l'échange, nous pouvons tirer parti de l'instruction batch de [`p-token`](https://solana.com/upgrades/p-token) afin d'exécuter efficacement toutes les opérations sur jetons en un seul appel CPI.
 
 ```rust
 impl<'a> Take<'a> {
   pub const DISCRIMINATOR: &'a u8 = &1;
+
+  const MAX_ACCOUNTS_LEN: usize = Transfer::MAX_ACCOUNTS_LEN * 2 + CloseAccount::MAX_ACCOUNTS_LEN;
+  const MAX_DATA_LEN: usize = Batch::header_data_len(3) + Transfer::DATA_LEN * 2 + CloseAccount::DATA_LEN;
 
   pub fn process(&mut self) -> ProgramResult {
     let data = self.accounts.escrow.try_borrow_data()?;
@@ -158,7 +159,8 @@ impl<'a> Take<'a> {
 
     let amount = TokenAccount::from_account_info(self.accounts.vault)?.amount();
 
-    let mut batch = Batch::default();
+    let batch_state = BatchState::new(Self::MAX_ACCOUNTS_LEN, Self::MAX_DATA_LEN);
+    let mut batch = batch_state.as_batch()?;
 
     Transfer::new(
       self.accounts.vault,
@@ -183,7 +185,7 @@ impl<'a> Take<'a> {
     )
     .into_batch(&mut batch)?;
 
-    batch.invoke_signed(&[signer.clone()])?;
+    batch.invoke_signed(&[signer])?;
 
     // Close the Escrow program account
     drop(data);
@@ -193,3 +195,5 @@ impl<'a> Take<'a> {
   }
 }
 ```
+
+> Assurez-vous que `pinocchio-token` est au moins en version `0.6.0` pour prendre en charge les opérations batch de [p-token](https://solana.com/upgrades/p-token).

--- a/src/app/content/challenges/pinocchio-escrow/fr/pages/take.mdx
+++ b/src/app/content/challenges/pinocchio-escrow/fr/pages/take.mdx
@@ -2,9 +2,9 @@
 
 L'instruction `take` finalise l'échange :
 
-- Transfére le Jeton A du vault au preneur.
+- Transfère le Jeton A du vault au preneur.
 - Ferme le compte de jetons du vault désormais vide.
-- Transférer le montant convenu du Jeton B du preneur au créateur.
+- Transfère le montant convenu du Jeton B du preneur au créateur.
 - Ferme le compte de programme `escrow`.
 
 <ArticleSection name="Comptes Nécessaires" id="required-accounts" level="h2" />

--- a/src/app/content/challenges/pinocchio-escrow/id/pages/make.mdx
+++ b/src/app/content/challenges/pinocchio-escrow/id/pages/make.mdx
@@ -188,12 +188,13 @@ impl<'a> Make<'a> {
     );
 
     // Transfer tokens to vault
-    Transfer {
-      from: self.accounts.maker_ata_a,
-      to: self.accounts.vault,
-      authority: self.accounts.maker,
-      amount: self.instruction_data.amount
-    }.invoke()?;
+    Transfer::new(
+      self.accounts.maker_ata_a,
+      self.accounts.vault,
+      self.accounts.maker,
+      self.instruction_data.amount,
+    )
+    .invoke()?;
 
     Ok(())
   }

--- a/src/app/content/challenges/pinocchio-escrow/id/pages/take.mdx
+++ b/src/app/content/challenges/pinocchio-escrow/id/pages/take.mdx
@@ -7,8 +7,6 @@ Instruksi `take` menyelesaikan pertukaran:
 - Memindahkan jumlah Token B yang disepakati dari pengambil ke pembuat.
 - Menutup akun program escrow.
 
-Dengan `p-token` yang sudah live di mainnet, ini adalah tempat yang tepat untuk menggunakan alur batch saat ini. Kita bisa memasukkan kedua transfer token dan penutupan vault ke dalam satu `Batch`.
-
 <ArticleSection name="Required Accounts" id="required-accounts" level="h2" />
 
 Berikut adalah akun yang dibutuhkan oleh konteks:
@@ -23,7 +21,7 @@ Berikut adalah akun yang dibutuhkan oleh konteks:
 - taker_ata_b: akun token terkait yang dimiliki oleh pengambil untuk mint_b. Harus dapat diubah
 - maker_ata_b: akun token terkait yang dimiliki oleh pembuat untuk mint_b. Harus dapat diubah
 - system_program: program sistem. Harus dapat dieksekusi
-- token_program: program token. Dengan `p-token` yang sudah live di mainnet, akun yang sama ini juga mendukung batching transfer token dalam instruksi ini. Harus dapat dieksekusi
+- token_program: program token. Harus dapat dieksekusi
 
 Dan kita melakukan pemeriksaan berikut padanya:
 
@@ -130,11 +128,14 @@ Sekarang kita bisa fokus pada logika itu sendiri yang akan:
 - Mentransfer token dari `taker_ata_b` ke `maker_ata_b`.
 - Menutup akun program `escrow` setelah pertukaran selesai.
 
-Perubahan utamanya adalah kita bisa membatch kedua transfer token dan penutupan vault, lalu memanggil program token hanya sekali. PDA escrow tetap perlu menandatangani karena ia mengotorisasi transfer keluar dari vault dan juga `CloseAccount` pada akun token tersebut. Karena itu batch diakhiri dengan `batch.invoke_signed(&[signer.clone()])?;`. Setelah itu kita tetap menutup `escrow` dengan `ProgramAccount::close`, karena itu adalah akun yang dimiliki program:
+Daripada melakukan tiga panggilan CPI token terpisah untuk menyelesaikan pertukaran, kita bisa memanfaatkan instruksi batch di [`p-token`](https://solana.com/upgrades/p-token) untuk menjalankan semua operasi token secara efisien dalam satu panggilan CPI.
 
 ```rust
 impl<'a> Take<'a> {
   pub const DISCRIMINATOR: &'a u8 = &1;
+
+  const MAX_ACCOUNTS_LEN: usize = Transfer::MAX_ACCOUNTS_LEN * 2 + CloseAccount::MAX_ACCOUNTS_LEN;
+  const MAX_DATA_LEN: usize = Batch::header_data_len(3) + Transfer::DATA_LEN * 2 + CloseAccount::DATA_LEN;
 
   pub fn process(&mut self) -> ProgramResult {
     let data = self.accounts.escrow.try_borrow_data()?;
@@ -158,7 +159,8 @@ impl<'a> Take<'a> {
 
     let amount = TokenAccount::from_account_info(self.accounts.vault)?.amount();
 
-    let mut batch = Batch::default();
+    let batch_state = BatchState::new(Self::MAX_ACCOUNTS_LEN, Self::MAX_DATA_LEN);
+    let mut batch = batch_state.as_batch()?;
 
     Transfer::new(
       self.accounts.vault,
@@ -183,7 +185,7 @@ impl<'a> Take<'a> {
     )
     .into_batch(&mut batch)?;
 
-    batch.invoke_signed(&[signer.clone()])?;
+    batch.invoke_signed(&[signer])?;
 
     // Close the Escrow program account
     drop(data);
@@ -193,3 +195,5 @@ impl<'a> Take<'a> {
   }
 }
 ```
+
+> Pastikan `pinocchio-token` setidaknya versi `0.6.0` untuk mendukung operasi batch [p-token](https://solana.com/upgrades/p-token).

--- a/src/app/content/challenges/pinocchio-escrow/id/pages/take.mdx
+++ b/src/app/content/challenges/pinocchio-escrow/id/pages/take.mdx
@@ -2,9 +2,12 @@
 
 Instruksi `take` menyelesaikan pertukaran:
 
-- Menutup catatan escrow, mengirimkan lamport sewanya kembali ke pembuat.
-- Memindahkan Token A dari vault ke pengambil, kemudian menutup vault.
+- Memindahkan Token A dari vault ke pengambil.
+- Menutup akun token vault yang sekarang kosong.
 - Memindahkan jumlah Token B yang disepakati dari pengambil ke pembuat.
+- Menutup akun program escrow.
+
+Dengan `p-token` yang sudah live di mainnet, ini adalah tempat yang tepat untuk menggunakan alur batch saat ini. Kita bisa memasukkan kedua transfer token dan penutupan vault ke dalam satu `Batch`.
 
 <ArticleSection name="Required Accounts" id="required-accounts" level="h2" />
 
@@ -20,7 +23,7 @@ Berikut adalah akun yang dibutuhkan oleh konteks:
 - taker_ata_b: akun token terkait yang dimiliki oleh pengambil untuk mint_b. Harus dapat diubah
 - maker_ata_b: akun token terkait yang dimiliki oleh pembuat untuk mint_b. Harus dapat diubah
 - system_program: program sistem. Harus dapat dieksekusi
-- token_program: program token. Harus dapat dieksekusi
+- token_program: program token. Dengan `p-token` yang sudah live di mainnet, akun yang sama ini juga mendukung batching transfer token dalam instruksi ini. Harus dapat dieksekusi
 
 Dan kita melakukan pemeriksaan berikut padanya:
 
@@ -122,9 +125,12 @@ impl<'a> TryFrom<&'a [AccountInfo]> for Take<'a> {
 
 Sekarang kita bisa fokus pada logika itu sendiri yang akan:
 
-- Mentransfer token dari `taker_ata_b` ke `maker_ata_b`.
 - Mentransfer token dari `vault` ke `taker_ata_a`.
-- Menutup `vault` yang sekarang kosong dan menarik biaya sewa dari akun tersebut.
+- Menutup akun token `vault` yang sekarang kosong dan menarik biaya sewanya.
+- Mentransfer token dari `taker_ata_b` ke `maker_ata_b`.
+- Menutup akun program `escrow` setelah pertukaran selesai.
+
+Perubahan utamanya adalah kita bisa membatch kedua transfer token dan penutupan vault, lalu memanggil program token hanya sekali. PDA escrow tetap perlu menandatangani karena ia mengotorisasi transfer keluar dari vault dan juga `CloseAccount` pada akun token tersebut. Karena itu batch diakhiri dengan `batch.invoke_signed(&[signer.clone()])?;`. Setelah itu kita tetap menutup `escrow` dengan `ProgramAccount::close`, karena itu adalah akun yang dimiliki program:
 
 ```rust
 impl<'a> Take<'a> {
@@ -152,30 +158,34 @@ impl<'a> Take<'a> {
 
     let amount = TokenAccount::from_account_info(self.accounts.vault)?.amount();
 
-    // Transfer from the Vault to the Taker
-    Transfer {
-      from: self.accounts.vault,
-      to: self.accounts.taker_ata_a,
-      authority: self.accounts.escrow,
+    let mut batch = Batch::default();
+
+    Transfer::new(
+      self.accounts.vault,
+      self.accounts.taker_ata_a,
+      self.accounts.escrow,
       amount,
-    }.invoke_signed(&[signer.clone()])?;
+    )
+    .into_batch(&mut batch)?;
 
-    // Close the Vault
-    CloseAccount {
-      account: self.accounts.vault,
-      destination: self.accounts.maker,
-      authority: self.accounts.escrow,
-    }.invoke_signed(&[signer.clone()])?;
+    CloseAccount::new(
+      self.accounts.vault,
+      self.accounts.maker,
+      self.accounts.escrow,
+    )
+    .into_batch(&mut batch)?;
 
-    // Transfer from the Taker to the Maker
-    Transfer {
-      from: self.accounts.taker_ata_b,
-      to: self.accounts.maker_ata_b,
-      authority: self.accounts.taker,
-      amount: escrow.receive,
-    }.invoke()?;
+    Transfer::new(
+      self.accounts.taker_ata_b,
+      self.accounts.maker_ata_b,
+      self.accounts.taker,
+      escrow.receive,
+    )
+    .into_batch(&mut batch)?;
 
-    // Close the Escrow
+    batch.invoke_signed(&[signer.clone()])?;
+
+    // Close the Escrow program account
     drop(data);
     ProgramAccount::close(self.accounts.escrow, self.accounts.taker)?;
 

--- a/src/app/content/challenges/pinocchio-escrow/uk/pages/make.mdx
+++ b/src/app/content/challenges/pinocchio-escrow/uk/pages/make.mdx
@@ -188,12 +188,13 @@ impl<'a> Make<'a> {
     );
 
     // Transfer tokens to vault
-    Transfer {
-      from: self.accounts.maker_ata_a,
-      to: self.accounts.vault,
-      authority: self.accounts.maker,
-      amount: self.instruction_data.amount
-    }.invoke()?;
+    Transfer::new(
+      self.accounts.maker_ata_a,
+      self.accounts.vault,
+      self.accounts.maker,
+      self.instruction_data.amount,
+    )
+    .invoke()?;
 
     Ok(())
   }

--- a/src/app/content/challenges/pinocchio-escrow/uk/pages/take.mdx
+++ b/src/app/content/challenges/pinocchio-escrow/uk/pages/take.mdx
@@ -2,9 +2,12 @@
 
 Інструкція `take` завершує обмін:
 
-- Закриває запис ескроу, повертаючи його лампорти оренди творцю.
-- Переміщує Токен A зі сховища до отримувача, потім закриває сховище.
+- Переміщує Токен A зі сховища до отримувача.
+- Закриває тепер порожній токен-акаунт сховища.
 - Переміщує узгоджену кількість Токену B від отримувача до творця.
+- Закриває програмний акаунт `escrow`.
+
+Оскільки `p-token` уже працює в mainnet, це гарне місце для використання поточного batch-потоку. Ми можемо помістити обидва токен-перекази та закриття сховища в один `Batch`.
 
 <ArticleSection name="Необхідні облікові записи" id="required-accounts" level="h2" />
 
@@ -20,7 +23,7 @@
 - taker_ata_b: пов'язаний обліковий запис токена, що належить отримувачу для mint_b. Має бути змінюваним
 - maker_ata_b: пов'язаний обліковий запис токена, що належить творцю для mint_b. Має бути змінюваним
 - system_program: системна програма. Має бути виконуваною
-- token_program: програма токенів. Має бути виконуваною
+- token_program: програма токенів. Оскільки `p-token` уже працює в mainnet, цей самий акаунт також підтримує batching токен-переказів у цій інструкції. Має бути виконуваною
 
 І ми виконуємо такі перевірки:
 
@@ -122,9 +125,12 @@ impl<'a> TryFrom<&'a [AccountInfo]> for Take<'a> {
 
 Тепер ми можемо зосередитися на самій логіці, яка буде:
 
-- Переказувати токени з `taker_ata_b` до `maker_ata_b`.
 - Переказувати токени з `vault` до `taker_ata_a`.
-- Закривати тепер порожній `vault` і виводити орендну плату з рахунку.
+- Закривати тепер порожній токен-акаунт `vault` і виводити його орендну плату.
+- Переказувати токени з `taker_ata_b` до `maker_ata_b`.
+- Закривати програмний акаунт `escrow` після завершення обміну.
+
+Головна зміна полягає в тому, що ми можемо забатчити обидва токен-перекази та закриття сховища, а потім викликати токен-програму лише один раз. PDA escrow все одно має підписати, оскільки вона авторизує як вихідний переказ зі сховища, так і `CloseAccount` для цього токен-акаунта. Тому batch завершується `batch.invoke_signed(&[signer.clone()])?;`. Після цього ми все одно закриваємо `escrow` через `ProgramAccount::close`, оскільки це акаунт, яким володіє програма:
 
 ```rust
 impl<'a> Take<'a> {
@@ -152,30 +158,34 @@ impl<'a> Take<'a> {
 
     let amount = TokenAccount::from_account_info(self.accounts.vault)?.amount();
 
-    // Transfer from the Vault to the Taker
-    Transfer {
-      from: self.accounts.vault,
-      to: self.accounts.taker_ata_a,
-      authority: self.accounts.escrow,
+    let mut batch = Batch::default();
+
+    Transfer::new(
+      self.accounts.vault,
+      self.accounts.taker_ata_a,
+      self.accounts.escrow,
       amount,
-    }.invoke_signed(&[signer.clone()])?;
+    )
+    .into_batch(&mut batch)?;
 
-    // Close the Vault
-    CloseAccount {
-      account: self.accounts.vault,
-      destination: self.accounts.maker,
-      authority: self.accounts.escrow,
-    }.invoke_signed(&[signer.clone()])?;
+    CloseAccount::new(
+      self.accounts.vault,
+      self.accounts.maker,
+      self.accounts.escrow,
+    )
+    .into_batch(&mut batch)?;
 
-    // Transfer from the Taker to the Maker
-    Transfer {
-      from: self.accounts.taker_ata_b,
-      to: self.accounts.maker_ata_b,
-      authority: self.accounts.taker,
-      amount: escrow.receive,
-    }.invoke()?;
+    Transfer::new(
+      self.accounts.taker_ata_b,
+      self.accounts.maker_ata_b,
+      self.accounts.taker,
+      escrow.receive,
+    )
+    .into_batch(&mut batch)?;
 
-    // Close the Escrow
+    batch.invoke_signed(&[signer.clone()])?;
+
+    // Close the Escrow program account
     drop(data);
     ProgramAccount::close(self.accounts.escrow, self.accounts.taker)?;
 

--- a/src/app/content/challenges/pinocchio-escrow/uk/pages/take.mdx
+++ b/src/app/content/challenges/pinocchio-escrow/uk/pages/take.mdx
@@ -7,8 +7,6 @@
 - Переміщує узгоджену кількість Токену B від отримувача до творця.
 - Закриває програмний акаунт `escrow`.
 
-Оскільки `p-token` уже працює в mainnet, це гарне місце для використання поточного batch-потоку. Ми можемо помістити обидва токен-перекази та закриття сховища в один `Batch`.
-
 <ArticleSection name="Необхідні облікові записи" id="required-accounts" level="h2" />
 
 Нижче наведені облікові записи, які потрібні для контексту:
@@ -23,7 +21,7 @@
 - taker_ata_b: пов'язаний обліковий запис токена, що належить отримувачу для mint_b. Має бути змінюваним
 - maker_ata_b: пов'язаний обліковий запис токена, що належить творцю для mint_b. Має бути змінюваним
 - system_program: системна програма. Має бути виконуваною
-- token_program: програма токенів. Оскільки `p-token` уже працює в mainnet, цей самий акаунт також підтримує batching токен-переказів у цій інструкції. Має бути виконуваною
+- token_program: програма токенів. Має бути виконуваною
 
 І ми виконуємо такі перевірки:
 
@@ -130,11 +128,14 @@ impl<'a> TryFrom<&'a [AccountInfo]> for Take<'a> {
 - Переказувати токени з `taker_ata_b` до `maker_ata_b`.
 - Закривати програмний акаунт `escrow` після завершення обміну.
 
-Головна зміна полягає в тому, що ми можемо забатчити обидва токен-перекази та закриття сховища, а потім викликати токен-програму лише один раз. PDA escrow все одно має підписати, оскільки вона авторизує як вихідний переказ зі сховища, так і `CloseAccount` для цього токен-акаунта. Тому batch завершується `batch.invoke_signed(&[signer.clone()])?;`. Після цього ми все одно закриваємо `escrow` через `ProgramAccount::close`, оскільки це акаунт, яким володіє програма:
+Замість трьох окремих токен-CPI-викликів для завершення обміну ми можемо скористатися batch-інструкцією в [`p-token`](https://solana.com/upgrades/p-token), щоб ефективно виконати всі токен-операції в одному CPI-виклику.
 
 ```rust
 impl<'a> Take<'a> {
   pub const DISCRIMINATOR: &'a u8 = &1;
+
+  const MAX_ACCOUNTS_LEN: usize = Transfer::MAX_ACCOUNTS_LEN * 2 + CloseAccount::MAX_ACCOUNTS_LEN;
+  const MAX_DATA_LEN: usize = Batch::header_data_len(3) + Transfer::DATA_LEN * 2 + CloseAccount::DATA_LEN;
 
   pub fn process(&mut self) -> ProgramResult {
     let data = self.accounts.escrow.try_borrow_data()?;
@@ -158,7 +159,8 @@ impl<'a> Take<'a> {
 
     let amount = TokenAccount::from_account_info(self.accounts.vault)?.amount();
 
-    let mut batch = Batch::default();
+    let batch_state = BatchState::new(Self::MAX_ACCOUNTS_LEN, Self::MAX_DATA_LEN);
+    let mut batch = batch_state.as_batch()?;
 
     Transfer::new(
       self.accounts.vault,
@@ -183,7 +185,7 @@ impl<'a> Take<'a> {
     )
     .into_batch(&mut batch)?;
 
-    batch.invoke_signed(&[signer.clone()])?;
+    batch.invoke_signed(&[signer])?;
 
     // Close the Escrow program account
     drop(data);
@@ -193,3 +195,5 @@ impl<'a> Take<'a> {
   }
 }
 ```
+
+> Переконайтеся, що `pinocchio-token` має щонайменше версію `0.6.0`, щоб підтримувати batch-операції [p-token](https://solana.com/upgrades/p-token).

--- a/src/app/content/challenges/pinocchio-escrow/vi/pages/make.mdx
+++ b/src/app/content/challenges/pinocchio-escrow/vi/pages/make.mdx
@@ -188,12 +188,13 @@ impl<'a> Make<'a> {
     );
 
     // Transfer tokens to vault
-    Transfer {
-      from: self.accounts.maker_ata_a,
-      to: self.accounts.vault,
-      authority: self.accounts.maker,
-      amount: self.instruction_data.amount
-    }.invoke()?;
+    Transfer::new(
+      self.accounts.maker_ata_a,
+      self.accounts.vault,
+      self.accounts.maker,
+      self.instruction_data.amount,
+    )
+    .invoke()?;
 
     Ok(())
   }

--- a/src/app/content/challenges/pinocchio-escrow/vi/pages/take.mdx
+++ b/src/app/content/challenges/pinocchio-escrow/vi/pages/take.mdx
@@ -7,8 +7,6 @@ Instruction `take` hoàn thiện việc hoán đổi:
 - Chuyển số lượng Token B đã thỏa thuận từ taker đến maker.
 - Đóng tài khoản chương trình escrow.
 
-Với `p-token` đã live trên mainnet, đây là nơi phù hợp để dùng luồng batch hiện tại. Chúng ta có thể đưa cả hai lần chuyển token và việc đóng vault vào cùng một `Batch`.
-
 <ArticleSection name="Các tài khoản cần thiết" id="required-accounts" level="h2" />
 
 Dưới đây là các tài khoản mà context cần:
@@ -23,7 +21,7 @@ Dưới đây là các tài khoản mà context cần:
 - taker_ata_b: tài khoản token liên kết thuộc sở hữu của taker cho mint_b. Phải là mutable
 - maker_ata_b: tài khoản token liên kết thuộc sở hữu của maker cho mint_b. Phải là mutable
 - system_program: chương trình hệ thống. Phải là executable
-- token_program: chương trình token. Với `p-token` đã live trên mainnet, cùng tài khoản này cũng hỗ trợ batching các lần chuyển token trong instruction này. Phải là executable
+- token_program: chương trình token. Phải là executable
 
 Và chúng ta thực hiện các kiểm tra này trên nó:
 
@@ -130,11 +128,14 @@ Bây giờ chúng ta có thể tập trung vào logic chính sẽ:
 - Chuyển token từ `taker_ata_b` đến `maker_ata_b`.
 - Đóng tài khoản chương trình `escrow` sau khi việc hoán đổi hoàn tất.
 
-Thay đổi chính là chúng ta có thể batch cả hai lần chuyển token và việc đóng vault, rồi chỉ invoke chương trình token một lần. PDA của escrow vẫn cần ký vì nó cấp quyền cho cả chuyển token ra khỏi vault và `CloseAccount` trên tài khoản token đó. Vì vậy batch kết thúc bằng `batch.invoke_signed(&[signer.clone()])?;`. Sau đó chúng ta vẫn đóng `escrow` bằng `ProgramAccount::close`, vì đó là tài khoản do chương trình sở hữu:
+Thay vì thực hiện ba lệnh gọi CPI token riêng biệt để hoàn tất việc hoán đổi, chúng ta có thể tận dụng batch instruction trong [`p-token`](https://solana.com/upgrades/p-token) để thực hiện hiệu quả tất cả các thao tác token chỉ trong một lần gọi CPI.
 
 ```rust
 impl<'a> Take<'a> {
   pub const DISCRIMINATOR: &'a u8 = &1;
+
+  const MAX_ACCOUNTS_LEN: usize = Transfer::MAX_ACCOUNTS_LEN * 2 + CloseAccount::MAX_ACCOUNTS_LEN;
+  const MAX_DATA_LEN: usize = Batch::header_data_len(3) + Transfer::DATA_LEN * 2 + CloseAccount::DATA_LEN;
 
   pub fn process(&mut self) -> ProgramResult {
     let data = self.accounts.escrow.try_borrow_data()?;
@@ -158,7 +159,8 @@ impl<'a> Take<'a> {
 
     let amount = TokenAccount::from_account_info(self.accounts.vault)?.amount();
 
-    let mut batch = Batch::default();
+    let batch_state = BatchState::new(Self::MAX_ACCOUNTS_LEN, Self::MAX_DATA_LEN);
+    let mut batch = batch_state.as_batch()?;
 
     Transfer::new(
       self.accounts.vault,
@@ -183,7 +185,7 @@ impl<'a> Take<'a> {
     )
     .into_batch(&mut batch)?;
 
-    batch.invoke_signed(&[signer.clone()])?;
+    batch.invoke_signed(&[signer])?;
 
     // Close the Escrow program account
     drop(data);
@@ -193,3 +195,5 @@ impl<'a> Take<'a> {
   }
 }
 ```
+
+> Hãy đảm bảo `pinocchio-token` có phiên bản ít nhất là `0.6.0` để hỗ trợ các thao tác batch của [p-token](https://solana.com/upgrades/p-token).

--- a/src/app/content/challenges/pinocchio-escrow/vi/pages/take.mdx
+++ b/src/app/content/challenges/pinocchio-escrow/vi/pages/take.mdx
@@ -2,9 +2,12 @@
 
 Instruction `take` hoàn thiện việc hoán đổi:
 
-- Đóng bản ghi escrow, gửi lamport tiền thuê về cho maker.
-- Chuyển Token A từ vault đến taker, sau đó đóng vault.
+- Chuyển Token A từ vault đến taker.
+- Đóng tài khoản token vault hiện đã trống.
 - Chuyển số lượng Token B đã thỏa thuận từ taker đến maker.
+- Đóng tài khoản chương trình escrow.
+
+Với `p-token` đã live trên mainnet, đây là nơi phù hợp để dùng luồng batch hiện tại. Chúng ta có thể đưa cả hai lần chuyển token và việc đóng vault vào cùng một `Batch`.
 
 <ArticleSection name="Các tài khoản cần thiết" id="required-accounts" level="h2" />
 
@@ -20,7 +23,7 @@ Dưới đây là các tài khoản mà context cần:
 - taker_ata_b: tài khoản token liên kết thuộc sở hữu của taker cho mint_b. Phải là mutable
 - maker_ata_b: tài khoản token liên kết thuộc sở hữu của maker cho mint_b. Phải là mutable
 - system_program: chương trình hệ thống. Phải là executable
-- token_program: chương trình token. Phải là executable
+- token_program: chương trình token. Với `p-token` đã live trên mainnet, cùng tài khoản này cũng hỗ trợ batching các lần chuyển token trong instruction này. Phải là executable
 
 Và chúng ta thực hiện các kiểm tra này trên nó:
 
@@ -122,9 +125,12 @@ impl<'a> TryFrom<&'a [AccountInfo]> for Take<'a> {
 
 Bây giờ chúng ta có thể tập trung vào logic chính sẽ:
 
-- Chuyển token từ `taker_ata_b` đến `maker_ata_b`.
 - Chuyển token từ `vault` đến `taker_ata_a`.
-- Đóng `vault` hiện đã trống và rút tiền thuê từ tài khoản.
+- Đóng tài khoản token `vault` hiện đã trống và thu lại tiền thuê của nó.
+- Chuyển token từ `taker_ata_b` đến `maker_ata_b`.
+- Đóng tài khoản chương trình `escrow` sau khi việc hoán đổi hoàn tất.
+
+Thay đổi chính là chúng ta có thể batch cả hai lần chuyển token và việc đóng vault, rồi chỉ invoke chương trình token một lần. PDA của escrow vẫn cần ký vì nó cấp quyền cho cả chuyển token ra khỏi vault và `CloseAccount` trên tài khoản token đó. Vì vậy batch kết thúc bằng `batch.invoke_signed(&[signer.clone()])?;`. Sau đó chúng ta vẫn đóng `escrow` bằng `ProgramAccount::close`, vì đó là tài khoản do chương trình sở hữu:
 
 ```rust
 impl<'a> Take<'a> {
@@ -152,30 +158,34 @@ impl<'a> Take<'a> {
 
     let amount = TokenAccount::from_account_info(self.accounts.vault)?.amount();
 
-    // Transfer from the Vault to the Taker
-    Transfer {
-      from: self.accounts.vault,
-      to: self.accounts.taker_ata_a,
-      authority: self.accounts.escrow,
+    let mut batch = Batch::default();
+
+    Transfer::new(
+      self.accounts.vault,
+      self.accounts.taker_ata_a,
+      self.accounts.escrow,
       amount,
-    }.invoke_signed(&[signer.clone()])?;
+    )
+    .into_batch(&mut batch)?;
 
-    // Close the Vault
-    CloseAccount {
-      account: self.accounts.vault,
-      destination: self.accounts.maker,
-      authority: self.accounts.escrow,
-    }.invoke_signed(&[signer.clone()])?;
+    CloseAccount::new(
+      self.accounts.vault,
+      self.accounts.maker,
+      self.accounts.escrow,
+    )
+    .into_batch(&mut batch)?;
 
-    // Transfer from the Taker to the Maker
-    Transfer {
-      from: self.accounts.taker_ata_b,
-      to: self.accounts.maker_ata_b,
-      authority: self.accounts.taker,
-      amount: escrow.receive,
-    }.invoke()?;
+    Transfer::new(
+      self.accounts.taker_ata_b,
+      self.accounts.maker_ata_b,
+      self.accounts.taker,
+      escrow.receive,
+    )
+    .into_batch(&mut batch)?;
 
-    // Close the Escrow
+    batch.invoke_signed(&[signer.clone()])?;
+
+    // Close the Escrow program account
     drop(data);
     ProgramAccount::close(self.accounts.escrow, self.accounts.taker)?;
 

--- a/src/app/content/challenges/pinocchio-escrow/zh-CN/pages/make.mdx
+++ b/src/app/content/challenges/pinocchio-escrow/zh-CN/pages/make.mdx
@@ -188,12 +188,13 @@ impl<'a> Make<'a> {
     );
 
     // Transfer tokens to vault
-    Transfer {
-      from: self.accounts.maker_ata_a,
-      to: self.accounts.vault,
-      authority: self.accounts.maker,
-      amount: self.instruction_data.amount
-    }.invoke()?;
+    Transfer::new(
+      self.accounts.maker_ata_a,
+      self.accounts.vault,
+      self.accounts.maker,
+      self.instruction_data.amount,
+    )
+    .invoke()?;
 
     Ok(())
   }

--- a/src/app/content/challenges/pinocchio-escrow/zh-CN/pages/take.mdx
+++ b/src/app/content/challenges/pinocchio-escrow/zh-CN/pages/take.mdx
@@ -7,8 +7,6 @@
 - 将约定数量的 Token B 从接受者转移到创建者。
 - 关闭 `escrow` 程序账户。
 
-由于 `p-token` 已经在主网上线，这里正适合使用当前的 batch 流程。我们可以把两次代币转移和 vault 的关闭放进同一个 `Batch`。
-
 <ArticleSection name="所需账户" id="required-accounts" level="h2" />
 
 以下是上下文所需的账户：
@@ -23,7 +21,7 @@
 - taker_ata_b：由接受者拥有的 mint_b 的关联代币账户。必须可变。
 - maker_ata_b：由创建者拥有的 mint_b 的关联代币账户。必须可变。
 - system_program：系统程序。必须可执行。
-- token_program：代币程序。由于 `p-token` 已经在主网上线，这个账户也支持在此指令中对代币转移进行 batching。必须可执行。
+- token_program：代币程序。必须可执行。
 
 我们对其执行以下检查：
 
@@ -130,11 +128,14 @@ impl<'a> TryFrom<&'a [AccountInfo]> for Take<'a> {
 - 将代币从 `taker_ata_b` 转移到 `maker_ata_b`。
 - 在交换完成后关闭 `escrow` 程序账户。
 
-这里最重要的变化是，我们可以把两次代币转移和 vault 的关闭放进 batch，然后只调用一次代币程序。Escrow PDA 仍然需要签名，因为它既要授权从 vault 转出，也要授权该代币账户上的 `CloseAccount`。因此 batch 会以 `batch.invoke_signed(&[signer.clone()])?;` 结束。之后我们仍然使用 `ProgramAccount::close` 来关闭 `escrow`，因为它是一个由程序拥有的账户：
+与其用三个独立的代币 CPI 调用来完成这次交换，我们可以利用 [`p-token`](https://solana.com/upgrades/p-token) 中的 batch instruction，把所有代币操作高效地合并到一次 CPI 调用中。
 
 ```rust
 impl<'a> Take<'a> {
   pub const DISCRIMINATOR: &'a u8 = &1;
+
+  const MAX_ACCOUNTS_LEN: usize = Transfer::MAX_ACCOUNTS_LEN * 2 + CloseAccount::MAX_ACCOUNTS_LEN;
+  const MAX_DATA_LEN: usize = Batch::header_data_len(3) + Transfer::DATA_LEN * 2 + CloseAccount::DATA_LEN;
 
   pub fn process(&mut self) -> ProgramResult {
     let data = self.accounts.escrow.try_borrow_data()?;
@@ -158,7 +159,8 @@ impl<'a> Take<'a> {
 
     let amount = TokenAccount::from_account_info(self.accounts.vault)?.amount();
 
-    let mut batch = Batch::default();
+    let batch_state = BatchState::new(Self::MAX_ACCOUNTS_LEN, Self::MAX_DATA_LEN);
+    let mut batch = batch_state.as_batch()?;
 
     Transfer::new(
       self.accounts.vault,
@@ -183,7 +185,7 @@ impl<'a> Take<'a> {
     )
     .into_batch(&mut batch)?;
 
-    batch.invoke_signed(&[signer.clone()])?;
+    batch.invoke_signed(&[signer])?;
 
     // Close the Escrow program account
     drop(data);
@@ -193,3 +195,5 @@ impl<'a> Take<'a> {
   }
 }
 ```
+
+> 请确保 `pinocchio-token` 至少为 `0.6.0` 版本，以支持 [p-token](https://solana.com/upgrades/p-token) 的批量操作。

--- a/src/app/content/challenges/pinocchio-escrow/zh-CN/pages/take.mdx
+++ b/src/app/content/challenges/pinocchio-escrow/zh-CN/pages/take.mdx
@@ -2,9 +2,12 @@
 
 `take` 指令完成交换操作：
 
-- 关闭托管记录，将其租金 lamports 返还给创建者。
-- 将 Token A 从保管库转移到接受者，然后关闭保管库。
+- 将 Token A 从保管库转移到接受者。
+- 关闭现在已空的 vault 代币账户。
 - 将约定数量的 Token B 从接受者转移到创建者。
+- 关闭 `escrow` 程序账户。
+
+由于 `p-token` 已经在主网上线，这里正适合使用当前的 batch 流程。我们可以把两次代币转移和 vault 的关闭放进同一个 `Batch`。
 
 <ArticleSection name="所需账户" id="required-accounts" level="h2" />
 
@@ -20,7 +23,7 @@
 - taker_ata_b：由接受者拥有的 mint_b 的关联代币账户。必须可变。
 - maker_ata_b：由创建者拥有的 mint_b 的关联代币账户。必须可变。
 - system_program：系统程序。必须可执行。
-- token_program：代币程序。必须可执行。
+- token_program：代币程序。由于 `p-token` 已经在主网上线，这个账户也支持在此指令中对代币转移进行 batching。必须可执行。
 
 我们对其执行以下检查：
 
@@ -122,9 +125,12 @@ impl<'a> TryFrom<&'a [AccountInfo]> for Take<'a> {
 
 现在我们可以专注于以下逻辑：
 
-- 将代币从`taker_ata_b`转移到`maker_ata_b`。
 - 将代币从`vault`转移到`taker_ata_a`。
-- 关闭现在已为空的`vault`并提取账户中的租金。
+- 关闭现在已为空的 `vault` 代币账户并提取其中的租金。
+- 将代币从 `taker_ata_b` 转移到 `maker_ata_b`。
+- 在交换完成后关闭 `escrow` 程序账户。
+
+这里最重要的变化是，我们可以把两次代币转移和 vault 的关闭放进 batch，然后只调用一次代币程序。Escrow PDA 仍然需要签名，因为它既要授权从 vault 转出，也要授权该代币账户上的 `CloseAccount`。因此 batch 会以 `batch.invoke_signed(&[signer.clone()])?;` 结束。之后我们仍然使用 `ProgramAccount::close` 来关闭 `escrow`，因为它是一个由程序拥有的账户：
 
 ```rust
 impl<'a> Take<'a> {
@@ -152,30 +158,34 @@ impl<'a> Take<'a> {
 
     let amount = TokenAccount::from_account_info(self.accounts.vault)?.amount();
 
-    // Transfer from the Vault to the Taker
-    Transfer {
-      from: self.accounts.vault,
-      to: self.accounts.taker_ata_a,
-      authority: self.accounts.escrow,
+    let mut batch = Batch::default();
+
+    Transfer::new(
+      self.accounts.vault,
+      self.accounts.taker_ata_a,
+      self.accounts.escrow,
       amount,
-    }.invoke_signed(&[signer.clone()])?;
+    )
+    .into_batch(&mut batch)?;
 
-    // Close the Vault
-    CloseAccount {
-      account: self.accounts.vault,
-      destination: self.accounts.maker,
-      authority: self.accounts.escrow,
-    }.invoke_signed(&[signer.clone()])?;
+    CloseAccount::new(
+      self.accounts.vault,
+      self.accounts.maker,
+      self.accounts.escrow,
+    )
+    .into_batch(&mut batch)?;
 
-    // Transfer from the Taker to the Maker
-    Transfer {
-      from: self.accounts.taker_ata_b,
-      to: self.accounts.maker_ata_b,
-      authority: self.accounts.taker,
-      amount: escrow.receive,
-    }.invoke()?;
+    Transfer::new(
+      self.accounts.taker_ata_b,
+      self.accounts.maker_ata_b,
+      self.accounts.taker,
+      escrow.receive,
+    )
+    .into_batch(&mut batch)?;
 
-    // Close the Escrow
+    batch.invoke_signed(&[signer.clone()])?;
+
+    // Close the Escrow program account
     drop(data);
     ProgramAccount::close(self.accounts.escrow, self.accounts.taker)?;
 

--- a/src/app/content/challenges/pinocchio-escrow/zh-HK/pages/make.mdx
+++ b/src/app/content/challenges/pinocchio-escrow/zh-HK/pages/make.mdx
@@ -188,12 +188,13 @@ impl<'a> Make<'a> {
     );
 
     // Transfer tokens to vault
-    Transfer {
-      from: self.accounts.maker_ata_a,
-      to: self.accounts.vault,
-      authority: self.accounts.maker,
-      amount: self.instruction_data.amount
-    }.invoke()?;
+    Transfer::new(
+      self.accounts.maker_ata_a,
+      self.accounts.vault,
+      self.accounts.maker,
+      self.instruction_data.amount,
+    )
+    .invoke()?;
 
     Ok(())
   }

--- a/src/app/content/challenges/pinocchio-escrow/zh-HK/pages/take.mdx
+++ b/src/app/content/challenges/pinocchio-escrow/zh-HK/pages/take.mdx
@@ -7,8 +7,6 @@
 - 將商定數量的 Token B 從接受者移至創建者。
 - 關閉 `escrow` 程式帳戶。
 
-由於 `p-token` 已經在主網上線，這裡很適合使用目前的 batch 流程。我們可以把兩次代幣轉移與 vault 的關閉放進同一個 `Batch`。
-
 <ArticleSection name="所需帳戶" id="required-accounts" level="h2" />
 
 以下是上下文所需的帳戶：
@@ -23,7 +21,7 @@
 - taker_ata_b：由接受者擁有的 mint_b 的關聯代幣帳戶。必須可變。
 - maker_ata_b：由創建者擁有的 mint_b 的關聯代幣帳戶。必須可變。
 - system_program：系統程序。必須可執行。
-- token_program：代幣程序。由於 `p-token` 已經在主網上線，這個帳戶也支援在此指令中對代幣轉移進行 batching。必須可執行。
+- token_program：代幣程序。必須可執行。
 
 我們對其進行以下檢查：
 
@@ -130,11 +128,14 @@ impl<'a> TryFrom<&'a [AccountInfo]> for Take<'a> {
 - 從 `taker_ata_b` 轉移代幣到 `maker_ata_b`。
 - 在交換完成後關閉 `escrow` 程式帳戶。
 
-這裡最重要的變化是，我們可以把兩次代幣轉移與 vault 的關閉放進 batch，然後只呼叫一次代幣程式。Escrow PDA 仍然需要簽名，因為它既要授權從 vault 轉出，也要授權該代幣帳戶上的 `CloseAccount`。因此 batch 會以 `batch.invoke_signed(&[signer.clone()])?;` 結束。之後我們仍然使用 `ProgramAccount::close` 來關閉 `escrow`，因為它是由程式擁有的帳戶：
+與其用三次獨立的 token CPI 呼叫來完成這次交換，我們可以利用 [`p-token`](https://solana.com/upgrades/p-token) 的 batch instruction，把所有 token 操作有效率地合併到一次 CPI 呼叫中。
 
 ```rust
 impl<'a> Take<'a> {
   pub const DISCRIMINATOR: &'a u8 = &1;
+
+  const MAX_ACCOUNTS_LEN: usize = Transfer::MAX_ACCOUNTS_LEN * 2 + CloseAccount::MAX_ACCOUNTS_LEN;
+  const MAX_DATA_LEN: usize = Batch::header_data_len(3) + Transfer::DATA_LEN * 2 + CloseAccount::DATA_LEN;
 
   pub fn process(&mut self) -> ProgramResult {
     let data = self.accounts.escrow.try_borrow_data()?;
@@ -158,7 +159,8 @@ impl<'a> Take<'a> {
 
     let amount = TokenAccount::from_account_info(self.accounts.vault)?.amount();
 
-    let mut batch = Batch::default();
+    let batch_state = BatchState::new(Self::MAX_ACCOUNTS_LEN, Self::MAX_DATA_LEN);
+    let mut batch = batch_state.as_batch()?;
 
     Transfer::new(
       self.accounts.vault,
@@ -183,7 +185,7 @@ impl<'a> Take<'a> {
     )
     .into_batch(&mut batch)?;
 
-    batch.invoke_signed(&[signer.clone()])?;
+    batch.invoke_signed(&[signer])?;
 
     // Close the Escrow program account
     drop(data);
@@ -193,3 +195,5 @@ impl<'a> Take<'a> {
   }
 }
 ```
+
+> 請確保 `pinocchio-token` 至少為 `0.6.0` 版本，以支援 [p-token](https://solana.com/upgrades/p-token) 的批次操作。

--- a/src/app/content/challenges/pinocchio-escrow/zh-HK/pages/take.mdx
+++ b/src/app/content/challenges/pinocchio-escrow/zh-HK/pages/take.mdx
@@ -2,9 +2,12 @@
 
 `take` 指令完成交換的最後步驟：
 
-- 關閉托管記錄，將其租金 lamports 返回給創建者。
-- 將 Token A 從保管庫移至接受者，然後關閉保管庫。
+- 將 Token A 從保管庫移至接受者。
+- 關閉現在已空的 vault 代幣帳戶。
 - 將商定數量的 Token B 從接受者移至創建者。
+- 關閉 `escrow` 程式帳戶。
+
+由於 `p-token` 已經在主網上線，這裡很適合使用目前的 batch 流程。我們可以把兩次代幣轉移與 vault 的關閉放進同一個 `Batch`。
 
 <ArticleSection name="所需帳戶" id="required-accounts" level="h2" />
 
@@ -20,7 +23,7 @@
 - taker_ata_b：由接受者擁有的 mint_b 的關聯代幣帳戶。必須可變。
 - maker_ata_b：由創建者擁有的 mint_b 的關聯代幣帳戶。必須可變。
 - system_program：系統程序。必須可執行。
-- token_program：代幣程序。必須可執行。
+- token_program：代幣程序。由於 `p-token` 已經在主網上線，這個帳戶也支援在此指令中對代幣轉移進行 batching。必須可執行。
 
 我們對其進行以下檢查：
 
@@ -122,9 +125,12 @@ impl<'a> TryFrom<&'a [AccountInfo]> for Take<'a> {
 
 現在我們可以專注於邏輯本身，該邏輯將：
 
-- 從`taker_ata_b`轉移代幣到`maker_ata_b`。
 - 從`vault`轉移代幣到`taker_ata_a`。
-- 關閉現在已空的`vault`並提取該帳戶的租金。
+- 關閉現在已空的 `vault` 代幣帳戶並提取其中的租金。
+- 從 `taker_ata_b` 轉移代幣到 `maker_ata_b`。
+- 在交換完成後關閉 `escrow` 程式帳戶。
+
+這裡最重要的變化是，我們可以把兩次代幣轉移與 vault 的關閉放進 batch，然後只呼叫一次代幣程式。Escrow PDA 仍然需要簽名，因為它既要授權從 vault 轉出，也要授權該代幣帳戶上的 `CloseAccount`。因此 batch 會以 `batch.invoke_signed(&[signer.clone()])?;` 結束。之後我們仍然使用 `ProgramAccount::close` 來關閉 `escrow`，因為它是由程式擁有的帳戶：
 
 ```rust
 impl<'a> Take<'a> {
@@ -152,30 +158,34 @@ impl<'a> Take<'a> {
 
     let amount = TokenAccount::from_account_info(self.accounts.vault)?.amount();
 
-    // Transfer from the Vault to the Taker
-    Transfer {
-      from: self.accounts.vault,
-      to: self.accounts.taker_ata_a,
-      authority: self.accounts.escrow,
+    let mut batch = Batch::default();
+
+    Transfer::new(
+      self.accounts.vault,
+      self.accounts.taker_ata_a,
+      self.accounts.escrow,
       amount,
-    }.invoke_signed(&[signer.clone()])?;
+    )
+    .into_batch(&mut batch)?;
 
-    // Close the Vault
-    CloseAccount {
-      account: self.accounts.vault,
-      destination: self.accounts.maker,
-      authority: self.accounts.escrow,
-    }.invoke_signed(&[signer.clone()])?;
+    CloseAccount::new(
+      self.accounts.vault,
+      self.accounts.maker,
+      self.accounts.escrow,
+    )
+    .into_batch(&mut batch)?;
 
-    // Transfer from the Taker to the Maker
-    Transfer {
-      from: self.accounts.taker_ata_b,
-      to: self.accounts.maker_ata_b,
-      authority: self.accounts.taker,
-      amount: escrow.receive,
-    }.invoke()?;
+    Transfer::new(
+      self.accounts.taker_ata_b,
+      self.accounts.maker_ata_b,
+      self.accounts.taker,
+      escrow.receive,
+    )
+    .into_batch(&mut batch)?;
 
-    // Close the Escrow
+    batch.invoke_signed(&[signer.clone()])?;
+
+    // Close the Escrow program account
     drop(data);
     ProgramAccount::close(self.accounts.escrow, self.accounts.taker)?;
 


### PR DESCRIPTION
## Summary

  This PR updates the Pinocchio Escrow lesson to reflect the current p-token batching flow while preserving the existing Blueshift lesson structure and voice.

  ## What Changed

  - keeps the make lesson aligned with the current token helper style by updating the transfer example to Transfer::new(...)
  - updates the take lesson across all localized pages to teach the batched p-token flow
  - clarifies the instruction order in take:
      - transfer Token A from vault to taker
      - close the vault token account
      - transfer Token B from taker to maker
      - close the escrow program account
  - explicitly distinguishes between:
      - vault as a token account closed with CloseAccount
      - escrow as a program-owned account closed with ProgramAccount::close
  - applies the same lesson update across all available localized make.mdx and take.mdx pages for the Pinocchio Escrow challenge

  ## Notes

  This keeps the escrow lesson aligned with the current p-token usage pattern while preserving the existing Blueshift challenge voice and structure.