### PR TITLE
Fix TransferFeeConfig wording in token extensions course

### DIFF
--- a/src/app/content/courses/token-2022-program/token-extensions/de.mdx
+++ b/src/app/content/courses/token-2022-program/token-extensions/de.mdx
@@ -25,7 +25,7 @@ Um sicherzustellen, dass der Gebührenempfänger nicht bei jedem Swap schreibges
 
 Aus genau diesem Grund benötigen wir für die Verwendung der `TransferFee` Erweiterung zwei verschiedene Arten von Erweiterungen: eine, die direkt auf das `Mint` Konto geht, genannt `TransferFeeConfig`, die alle Daten enthält, die für einen Swap benötigt werden, und eine andere, die auf das `Token` Konto geht, genannt `TransferFeeAmount`, die "registriert", wie viel Token vom Token-Konto einbehalten wird.
 
-So sehen die Daten der `TransferFee` Erweiterung aus:
+So sehen die Daten der `TransferFeeConfig` Erweiterung aus:
 
 ```rust
 /// TransferFeeConfig Extension

--- a/src/app/content/courses/token-2022-program/token-extensions/en.mdx
+++ b/src/app/content/courses/token-2022-program/token-extensions/en.mdx
@@ -25,7 +25,7 @@ To make sure that the fee recipient doesn't get write-locked every time somebody
 
 For this exact reason, to use the `TransferFee` extension, we need 2 different types of extensions: one that goes directly on the `Mint` account called `TransferFeeConfig` that has all the data needed to perform a swap, and another one that goes on the `Token` account called `TransferFeeAmount` that "registers" how much token is withheld by the token account.
 
-This is how the `TransferFee` Extension data looks:
+This is how the `TransferFeeConfig` Extension data looks:
 
 ```rust
 /// TransferFeeConfig Extension

--- a/src/app/content/courses/token-2022-program/token-extensions/fr.mdx
+++ b/src/app/content/courses/token-2022-program/token-extensions/fr.mdx
@@ -25,7 +25,7 @@ Pour éviter que le destinataire des frais ne soit bloqué en écriture à chaqu
 
 C'est pour cette raison que, pour utiliser l'extension `TransferFee`, nous avons besoin de deux types d'extensions différents : une qui va directement dans le compte de `Mint` appelée `TransferFeeConfig` qui contient toutes les données nécessaires pour effectuer un échange, et une autre qui va dans le compte de`Token` appelée `TransferFeeAmount` qui "enregistre" la quantité de jetons conservée par le compte de jetons.
 
-Voici à quoi ressemblent les données de l'extension `TransferFee` :
+Voici à quoi ressemblent les données de l'extension `TransferFeeConfig` :
 
 ```rust
 /// TransferFeeConfig Extension

--- a/src/app/content/courses/token-2022-program/token-extensions/id.mdx
+++ b/src/app/content/courses/token-2022-program/token-extensions/id.mdx
@@ -25,7 +25,7 @@ Untuk memastikan bahwa penerima biaya tidak mendapatkan write-lock setiap kali s
 
 Untuk alasan ini, untuk menggunakan ekstensi `TransferFee`, kita memerlukan 2 jenis ekstensi yang berbeda: satu yang langsung masuk ke akun `Mint` yang disebut `TransferFeeConfig` yang memiliki semua data yang diperlukan untuk melakukan swap, dan satu lagi yang masuk ke akun `Token` yang disebut `TransferFeeAmount` yang "mendaftarkan" berapa banyak token yang ditahan oleh akun token.
 
-Beginilah tampilan data Ekstensi `TransferFee`:
+Beginilah tampilan data Ekstensi `TransferFeeConfig`:
 
 ```rust
 /// TransferFeeConfig Extension

--- a/src/app/content/courses/token-2022-program/token-extensions/pt-BR.mdx
+++ b/src/app/content/courses/token-2022-program/token-extensions/pt-BR.mdx
@@ -25,7 +25,7 @@ Para garantir que o destinatário da taxa não seja bloqueado para escrita toda 
 
 Por esse exato motivo, para usar a extensão `TransferFee`, precisamos de 2 tipos diferentes de extensões: uma que vai diretamente na conta `Mint` chamada `TransferFeeConfig` que contém todos os dados necessários para realizar uma troca, e outra que vai na conta `Token` chamada `TransferFeeAmount` que "registra" quanto token está retido pela token account.
 
-É assim que os dados da extensão `TransferFee` se parecem:
+É assim que os dados da extensão `TransferFeeConfig` se parecem:
 
 ```rust
 /// TransferFeeConfig Extension

--- a/src/app/content/courses/token-2022-program/token-extensions/uk.mdx
+++ b/src/app/content/courses/token-2022-program/token-extensions/uk.mdx
@@ -25,7 +25,7 @@ import { ArticleSection } from "../../../../components/ArticleSection/ArticleSec
 
 Саме з цієї причини для використання розширення `TransferFee` нам потрібні 2 різні типи розширень: одне, яке йде безпосередньо на рахунок `Mint`, що називається `TransferFeeConfig`, яке містить усі дані, необхідні для виконання обміну, та інше, яке йде на рахунок `Token`, що називається `TransferFeeAmount`, яке "реєструє", скільки токенів утримується токен-рахунком.
 
-Ось як виглядають дані розширення `TransferFee`:
+Ось як виглядають дані розширення `TransferFeeConfig`:
 
 ```rust
 /// TransferFeeConfig Extension

--- a/src/app/content/courses/token-2022-program/token-extensions/vi.mdx
+++ b/src/app/content/courses/token-2022-program/token-extensions/vi.mdx
@@ -25,7 +25,7 @@ Phần mở rộng `TransferFee` là một `Mint` extension cho phép creator đ
 
 Chính vì lý do này, để sử dụng phần mở rộng `TransferFee`, chúng ta cần 2 loại phần mở rộng khác nhau: một cái nằm trực tiếp trên `Mint` account được gọi là `TransferFeeConfig` có tất cả dữ liệu cần thiết để thực hiện swap, và một cái khác đặt trên `Token` account được gọi là `TransferFeeAmount` "đăng ký" bao nhiêu token bị giữ lại bởi token account.
 
-Dữ liệu của phần mở rộng `TransferFee` trông như thế này:
+Dữ liệu của phần mở rộng `TransferFeeConfig` trông như thế này:
 
 ```rust
 /// TransferFeeConfig Extension

--- a/src/app/content/courses/token-2022-program/token-extensions/zh-CN.mdx
+++ b/src/app/content/courses/token-2022-program/token-extensions/zh-CN.mdx
@@ -25,7 +25,7 @@ Token Extensions 旨在具有可组合性，允许您结合多个扩展来创建
 
 正因如此，要使用 `TransferFee` 扩展，我们需要两种不同类型的扩展：一种直接应用于 `Mint` 账户，称为 `TransferFeeConfig`，它包含执行交换所需的所有数据；另一种应用于 `Token` 账户，称为 `TransferFeeAmount`，它“注册”了代币账户扣留的代币数量。
 
-以下是 `TransferFee` 扩展数据的样子：
+以下是 `TransferFeeConfig` 扩展数据的样子：
 
 ```rust
 /// TransferFeeConfig Extension

--- a/src/app/content/courses/token-2022-program/token-extensions/zh-HK.mdx
+++ b/src/app/content/courses/token-2022-program/token-extensions/zh-HK.mdx
@@ -25,7 +25,7 @@ import { ArticleSection } from "../../../../components/ArticleSection/ArticleSec
 
 正因如此，要使用 `TransferFee` 擴展，我們需要兩種類型的擴展：一種直接應用於 `Mint` 帳戶，稱為 `TransferFeeConfig`，它包含執行交換所需的所有數據；另一種應用於 `Token` 帳戶，稱為 `TransferFeeAmount`，用於“註冊”代幣帳戶扣留了多少代幣。
 
-以下是 `TransferFee` 擴展數據的外觀：
+以下是 `TransferFeeConfig` 擴展數據的外觀：
 
 ```rust
 /// TransferFeeConfig Extension


### PR DESCRIPTION
 Fix TransferFeeConfig wording in the Token Extensions course.

This updates the intro sentence before the code example so it refers to TransferFeeConfig instead of TransferFee, matching the actual struct shown. The same wording fix is applied across the localized course files to keep translations in sync.