### PR TITLE
fix: add missing pt-BR pages for Pinocchio AMM challenge

### DIFF
--- a/src/app/content/challenges/pinocchio-amm/pt-BR/pages/conclusion.mdx
+++ b/src/app/content/challenges/pinocchio-amm/pt-BR/pages/conclusion.mdx
@@ -1,0 +1,14 @@
+# Conclusão
+
+Agora você pode testar seu programa contra nossos testes unitários e reivindicar seus NFTs!
+
+Comece compilando seu programa usando o seguinte comando no seu terminal:
+
+```
+cargo build-sbf
+```
+
+Isso gera um arquivo `.so` diretamente na sua pasta `target/deploy`.
+
+Agora clique no botão `take challenge` e solte o arquivo lá!
+

--- a/src/app/content/challenges/pinocchio-amm/pt-BR/pages/deposit.mdx
+++ b/src/app/content/challenges/pinocchio-amm/pt-BR/pages/deposit.mdx
@@ -1,0 +1,222 @@
+# Deposit
+
+A instrução `deposit` realiza três tarefas principais:
+
+- Deposita os tokens `mint_x` e `mint_y` com base na quantidade de LP que o usuário deseja `mint`.
+- Calcula a quantidade a ser depositada e verifica se a quantidade não é maior que `max_x` e `max_y` designados pelo usuário.
+- Realiza o mint da quantidade correta de `mint_lp` na ATA do usuário.
+
+> Como mencionado na seção da instrução `initialize`; vamos inicializar todas as `Associated Token Accounts` fora da nossa instrução para fins de otimização.
+
+<ArticleSection name="Contas Necessárias" id="required-accounts" level="h2" />
+
+Abaixo estão as contas necessárias para este contexto:
+
+- `user`: O usuário que está depositando os tokens na liquidez do AMM. Deve ser um `signer`.
+- `mint_lp`: A conta Mint que representará a liquidez do pool. Deve ser passada como `mutable`.
+- `vault_x`: A conta de token que contém todo o token X depositado no pool. Deve ser passada como `mutable`.
+- `vault_y`: A conta de token que contém todo o token Y depositado no pool. Deve ser passada como `mutable`.
+- `user_x_ata`: A conta de token associada do usuário para o token X. Esta é a conta de origem da qual o token X do usuário será transferido para o pool. Deve ser passada como `mutable`.
+- `user_y_ata`: A conta de token associada do usuário para o token Y. Esta é a conta de origem da qual o token Y do usuário será transferido para o pool. Deve ser passada como `mutable`.
+- `user_lp_ata`: A conta de token associada do usuário para tokens LP. Esta é a conta de destino onde os tokens LP serão cunhados. Deve ser passada como `mutable`.
+- `config`: A conta de configuração do pool AMM. Armazena todos os parâmetros e estado relevantes do pool.
+- `token program`: A conta do programa SPL Token. Isso é necessário para realizar operações de token como transferências e mint. Deve ser `executable`.
+
+Aqui, novamente, vou deixar a implementação para você:
+
+```rust
+pub struct DepositAccounts<'a> {
+    pub user: &'a AccountInfo,
+    pub mint_lp: &'a AccountInfo,
+    pub vault_x: &'a AccountInfo,
+    pub vault_y: &'a AccountInfo,
+    pub user_x_ata: &'a AccountInfo,
+    pub user_y_ata: &'a AccountInfo,
+    pub user_lp_ata: &'a AccountInfo,
+    pub config: &'a AccountInfo,
+    pub token_program: &'a AccountInfo,
+}
+
+impl<'a> TryFrom<&'a [AccountInfo]> for DepositAccounts<'a> {
+  type Error = ProgramError;
+
+  fn try_from(accounts: &'a [AccountInfo]) -> Result<Self, Self::Error> {
+    //..
+  }
+}
+```
+
+<ArticleSection name="Dados da Instrução" id="instruction-data" level="h2" />
+
+Aqui estão os dados da instrução que precisamos passar:
+
+- `amount`: A quantidade de tokens LP que o usuário deseja receber. Deve ser um `[u64]`
+- `max_x`: A quantidade máxima de token X que o usuário está disposto a depositar. Deve ser um `[u64]`
+- `max_y`: A quantidade máxima de token Y que o usuário está disposto a depositar. Deve ser um `[u64]`
+- `expiration`: A expiração desta ordem. Importante para garantir que a transação seja executada em um determinado período de tempo. Deve ser um `[i64]`
+
+Vamos lidar com a implementação do `DepositInstructionData` da mesma forma que a inicialização. Então vou deixar a implementação para você:
+
+```rust
+pub struct DepositInstructionData {
+    pub amount: u64,
+    pub max_x: u64,
+    pub max_y: u64,
+    pub expiration: i64,
+}
+
+impl<'a> TryFrom<&'a [u8]> for DepositInstructionData {
+    type Error = ProgramError;
+
+    fn try_from(data: &'a [u8]) -> Result<Self, Self::Error> {
+        //..
+    }
+}
+```
+
+> Certifique-se de que qualquer quantidade, como `amount`, `max_y` e `max_x`, seja maior que zero e que a ordem ainda não tenha expirado usando o sysvar `Clock`.
+
+<ArticleSection name="Lógica da Instrução" id="instruction-logic" level="h2" />
+
+Começamos desserializando tanto o `instruction_data` quanto o `accounts`.
+
+Em seguida, precisamos:
+
+- Carregar a conta `Config` para obter todos os dados dentro dela. Podemos fazer isso usando o helper `Config::load()`.
+- Verificar se o `AmmState` é válido (ou seja, se é igual a `AmmState::Initialized`)
+- Verificar a derivação de `vault_x` e `vault_y` para serem Associated Token Accounts assim:
+
+```rust
+// Verifica se o vault_x é válido
+let (vault_x, _) = find_program_address(
+    &[
+        self.accounts.config.key(),
+        self.accounts.token_program.key(),
+        config.mint_x(),
+    ],
+    &pinocchio_associated_token_account::ID,
+);
+
+if vault_x.ne(self.accounts.vault_x.key()) {
+    return Err(ProgramError::InvalidAccountData);
+}
+```
+
+- Desserializar todas as contas de token envolvidas e usar os dados dentro delas para calcular a quantidade a depositar usando o crate `constant-product-curve` e verificando o slippage assim:
+
+```rust
+// Desserializar as contas de token
+let mint_lp = unsafe { Mint::from_account_info_unchecked(self.accounts.mint_lp)? };
+let vault_x = unsafe { TokenAccount::from_account_info_unchecked(self.accounts.vault_x)? };
+let vault_y = unsafe { TokenAccount::from_account_info_unchecked(self.accounts.vault_y)? };
+
+// Obter as quantidades para depositar
+let (x, y) = match mint_lp.supply() == 0 && vault_x.amount() == 0 && vault_y.amount() == 0 {
+    true => (self.instruction_data.max_x, self.instruction_data.max_y),
+    false => {
+        let amounts = ConstantProduct::xy_deposit_amounts_from_l(
+            vault_x.amount(),
+            vault_y.amount(),
+            mint_lp.supply(),
+            self.instruction_data.amount,
+            6,
+        )
+        .map_err(|_| ProgramError::InvalidArgument)?;
+
+        (amounts.x, amounts.y)
+    }
+};
+
+// Verificar slippage
+if !(x <= self.instruction_data.max_x && y <= self.instruction_data.max_y) {
+    return Err(ProgramError::InvalidArgument);
+}
+```
+
+> Se for o primeiro depósito, podemos pular o cálculo dos tokens LP e dos depósitos e simplesmente usar o valor que o usuário sugeriu
+
+- Transferir as quantidades das contas de token do usuário para as vaults e realizar o mint da quantidade apropriada de tokens LP para a conta de token do usuário.
+
+Graças ao upgrade [`p-token`](https://solana.com/upgrades/p-token), podemos agrupar as transferências de token e o mint de tokens LP em uma única CPI, em vez de fazer três chamadas CPI separadas.
+
+```rust
+use pinocchio_token::instructions::{Batch, BatchState, MintTo, Transfer};
+
+/// O número de contas para a instrução de batch.
+const MAX_ACCOUNTS_LEN: usize =
+    Transfer::MAX_ACCOUNTS_LEN * 2
+    + MintTo::MAX_ACCOUNTS_LEN;
+
+/// O comprimento dos dados da instrução para a instrução de batch.
+const MAX_DATA_LEN: usize = Batch::header_data_len(3)
+    + Transfer::DATA_LEN * 2
+    + MintTo::DATA_LEN;
+
+// ...
+
+let mut batch_state = BatchState::new(MAX_ACCOUNTS_LEN, MAX_DATA_LEN);
+let mut batch = batch_state.as_batch()?;
+
+Transfer::new(
+    self.accounts.user_x_ata,
+    self.accounts.vault_x,
+    self.accounts.user,
+    x,
+)
+.into_batch(&mut batch)?;
+
+Transfer::new(
+    self.accounts.user_y_ata,
+    self.accounts.vault_y,
+    self.accounts.user,
+    y,
+)
+.into_batch(&mut batch)?;
+
+MintTo::new(
+    self.accounts.mint_lp,
+    self.accounts.user_lp_ata,
+    self.accounts.config,
+    self.instruction_data.amount,
+)
+.into_batch(&mut batch)?;
+
+batch.invoke_signed(&[signer])?;
+```
+
+> Certifique-se de que `pinocchio-token` esteja pelo menos na versão `0.6.0` para suportar operações de batch do [p-token](https://solana.com/upgrades/p-token).
+
+Você deve ser proficiente o suficiente para fazer o resto por conta própria, então vou deixar a implementação para você:
+
+```rust
+pub struct Deposit<'a> {
+    pub accounts: DepositAccounts<'a>,
+    pub instruction_data: DepositInstructionData,
+}
+
+impl<'a> TryFrom<(&'a [u8], &'a [AccountInfo])> for Deposit<'a> {
+    type Error = ProgramError;
+
+    fn try_from((data, accounts): (&'a [u8], &'a [AccountInfo])) -> Result<Self, Self::Error> {
+        let accounts = DepositAccounts::try_from(accounts)?;
+        let instruction_data = DepositInstructionData::try_from(data)?;
+
+        // Retorna a struct inicializada
+        Ok(Self {
+            accounts,
+            instruction_data,
+        })
+    }
+}
+
+impl<'a> Deposit<'a> {
+    pub const DISCRIMINATOR: &'a u8 = &1;
+
+    pub fn process(&mut self) -> ProgramResult {
+      //..
+
+      Ok(())
+    }
+}
+```
+

--- a/src/app/content/challenges/pinocchio-amm/pt-BR/pages/initialize.mdx
+++ b/src/app/content/challenges/pinocchio-amm/pt-BR/pages/initialize.mdx
@@ -1,0 +1,180 @@
+# Initialize
+
+A instrução `initialize` realiza duas tarefas principais:
+
+- Inicializa a conta `Config` e armazena todas as informações necessárias para o AMM funcionar corretamente.
+- Cria a conta Mint `mint_lp` e atribui a `mint_authority` à conta `config`.
+
+> Não vamos inicializar nenhuma Associated Token Account (ATA) aqui, pois isso é frequentemente desnecessário e pode ser um desperdício. Nas instruções subsequentes `deposit`, `withdraw` e `swap`, verificaremos se os tokens estão sendo depositados nas ATAs corretas. No entanto, você deve criar um helper "initializeAccount" no frontend para gerar essas contas sob demanda.
+
+<ArticleSection name="Contas Necessárias" id="required-accounts" level="h2" />
+
+Abaixo estão as contas necessárias para este contexto:
+
+- `initializer`: O criador da conta `config`. Isso não precisa necessariamente ser também a autoridade sobre ela. Deve ser um `signer` e `mutable`, pois esta conta pagará pela inicialização tanto do `config` quanto do `mint_lp`.
+- `mint_lp`: A conta Mint que representará a liquidez do pool. A `mint_authority` deve ser definida como a conta `config`. Deve ser passada como `mutable`.
+- `config`: A conta de configuração sendo inicializada. Deve ser `mutable`.
+- Programas `system` e `token`: Contas de programa necessárias para inicializar as contas acima. Devem ser `executable`.
+
+> À medida que você ganha mais experiência, notará que muitas dessas verificações podem ser omitidas, contando com as restrições impostas pelas próprias CPIs. Por exemplo, para este struct de contas, nenhuma verificação explícita é necessária; se as restrições não forem atendidas, o programa falhará por padrão. Apontarei essas nuances conforme avançamos pela lógica.
+
+Como não há muitas mudanças em relação ao struct usual que criamos, vou deixar a implementação para você:
+
+```rust
+pub struct InitializeAccounts<'a> {
+    pub initializer: &'a AccountInfo,
+    pub mint_lp: &'a AccountInfo,
+    pub config: &'a AccountInfo,
+}
+
+impl<'a> TryFrom<&'a [AccountInfo]> for InitializeAccounts<'a> {
+  type Error = ProgramError;
+
+  fn try_from(accounts: &'a [AccountInfo]) -> Result<Self, Self::Error> {
+    //..
+  }
+}
+```
+
+> Você precisará passar todas as contas discutidas acima, mas nem todas precisam ser incluídas no struct `InitializeAccounts`, já que você pode não precisar referenciar diretamente todas as contas na implementação.
+
+<ArticleSection name="Dados da Instrução" id="instruction-data" level="h2" />
+
+Aqui estão os dados da instrução que precisamos passar:
+
+- `seed`: Um número aleatório usado para derivação de seeds PDA (Program Derived Address). Isso permite instâncias únicas de pool. Deve ser um `[u64]`
+- `fee`: A taxa de swap, expressa em basis points (1 basis point = 0,01%). Esta taxa é coletada em cada negociação e distribuída aos provedores de liquidez. Deve ser um `[u16]`
+- `mint_x`: O endereço da mint SPL token para o token X no pool. Deve ser um `[u8; 32]`
+- `mint_y`: O endereço da mint SPL token para o token Y no pool. Deve ser um `[u8; 32]`
+- `config_bump`: A seed de bump usada para derivar o PDA da conta `config`. Deve ser um `u8`
+- `lp_bump`: A seed de bump usada para derivar o PDA da conta `lp_mint`. Deve ser um `u8`
+- `authority`: A chave pública que terá autoridade administrativa sobre o AMM. Se não fornecida, o pool pode ser definido como imutável. Deve ser um `[u8; 32]`
+
+> Como você pode ver, vários desses campos poderiam ser derivados de forma diferente. Por exemplo, poderíamos obter `mint_x` passando a conta `Mint` e lendo-a diretamente de lá, ou gerar o valor `bump` dentro do próprio programa. No entanto, ao passá-los explicitamente, estamos visando criar o programa mais otimizado e eficiente possível.
+
+Nesta implementação, estamos lidando com o parsing dos dados da instrução de uma forma mais flexível e de baixo nível do que o usual. Por esta razão, explicaremos por que estamos tomando as seguintes decisões:
+
+```rust
+#[repr(C, packed)]
+pub struct InitializeInstructionData {
+    pub seed: u64,
+    pub fee: u16,
+    pub mint_x: [u8; 32],
+    pub mint_y: [u8; 32],
+    pub config_bump: [u8; 1],
+    pub lp_bump: [u8; 1],
+    pub authority: [u8; 32],
+}
+
+impl TryFrom<&[u8]> for InitializeInstructionData {
+    type Error = ProgramError;
+
+    fn try_from(data: &[u8]) -> Result<Self, Self::Error> {
+        const INITIALIZE_DATA_LEN_WITH_AUTHORITY: usize = size_of::<InitializeInstructionData>();
+        const INITIALIZE_DATA_LEN: usize =
+            INITIALIZE_DATA_LEN_WITH_AUTHORITY - size_of::<[u8; 32]>();
+
+        match data.len() {
+            INITIALIZE_DATA_LEN_WITH_AUTHORITY => {
+                Ok(unsafe { (data.as_ptr() as *const Self).read_unaligned() })
+            }
+            INITIALIZE_DATA_LEN => {
+                // Se a authority não estiver presente, precisamos construir o buffer e adicioná-la no final antes de transmutar para o struct
+                let mut raw: MaybeUninit<[u8; INITIALIZE_DATA_LEN_WITH_AUTHORITY]> = MaybeUninit::uninit();
+                let raw_ptr = raw.as_mut_ptr() as *mut u8;
+                unsafe {
+                    // Copiar os dados fornecidos
+                    core::ptr::copy_nonoverlapping(data.as_ptr(), raw_ptr, INITIALIZE_DATA_LEN);
+                    // Adicionar a authority ao final do buffer
+                    core::ptr::write_bytes(raw_ptr.add(INITIALIZE_DATA_LEN), 0, 32);
+                    // Agora transmutar para o struct
+                    Ok((raw.as_ptr() as *const Self).read_unaligned())
+                }
+            }
+            _ => Err(ProgramError::InvalidInstructionData),
+        }
+    }
+}
+```
+
+O campo authority em `InitializeInstructionData` é opcional e pode ser omitido para criar um pool imutável.
+
+Para facilitar isso e economizar 32 bytes de dados de transação ao criar pools imutáveis, verificamos o comprimento dos dados da instrução e fazemos o parsing de acordo; se os dados forem mais curtos, definimos o campo authority como `None` escrevendo 32 bytes zero no final do buffer; se incluir o campo `authority` completo, fazemos o cast do slice de bytes diretamente para o struct.
+
+<ArticleSection name="Lógica da Instrução" id="instruction-logic" level="h2" />
+
+Começamos desserializando tanto o `instruction_data` quanto o `accounts`.
+
+Em seguida, precisamos:
+
+- Criar a conta `Config` usando a instrução `CreateAccount` do programa de sistema e as seguintes seeds:
+
+```rust
+let seed_binding = self.instruction_data.seed.to_le_bytes();
+let config_seeds = [
+    Seed::from(b"config"),
+    Seed::from(&seed_binding),
+    Seed::from(&self.instruction_data.mint_x),
+    Seed::from(&self.instruction_data.mint_y),
+    Seed::from(&self.instruction_data.config_bump),
+];
+```
+
+- Popular a conta `Config` carregando-a usando o helper `Config::load_mut_unchecked()` e então preenchendo-a com todos os dados necessários usando o helper `config.set_inner()`.
+- Criar a conta `Mint` para o LP usando as instruções `CreateAccount` e `InitializeMint2` e as seguintes seeds:
+
+```rust
+let mint_lp_seeds = [
+    Seed::from(b"mint_lp"),
+    Seed::from(self.accounts.config.key()),
+    Seed::from(&self.instruction_data.lp_bump),
+];
+```
+
+> A `mint_authority` do `mint_lp` é a conta `config`
+
+Você deve ser proficiente o suficiente para fazer isso por conta própria, então vou deixar a implementação para você:
+
+```rust
+pub struct Initialize<'a> {
+    pub accounts: InitializeAccounts<'a>,
+    pub instruction_data: InitializeInstructionData,
+}
+
+impl<'a> TryFrom<(&'a [u8], &'a [AccountInfo])> for Initialize<'a> {
+    type Error = ProgramError;
+
+    fn try_from((data, accounts): (&'a [u8], &'a [AccountInfo])) -> Result<Self, Self::Error> {
+        let accounts = InitializeAccounts::try_from(accounts)?;
+        let instruction_data: InitializeInstructionData = InitializeInstructionData::try_from(data)?;
+
+        Ok(Self {
+            accounts,
+            instruction_data,
+        })
+    }
+}
+
+impl<'a> Initialize<'a> {
+    pub const DISCRIMINATOR: &'a u8 = &0;
+
+    pub fn process(&mut self) -> ProgramResult {
+      //..
+
+      Ok(())
+    }
+}
+```
+
+<ArticleSection name="Segurança" id="security" level="h2" />
+
+Como mencionado anteriormente, pode parecer incomum, mas não precisamos realizar verificações explícitas nas contas que estão sendo passadas.
+
+Isso ocorre porque, na prática, a instrução falhará se algo estiver errado; seja durante uma CPI (Cross-Program Invocation) ou antecipadamente através de verificações que colocamos no programa.
+
+Por exemplo, considere a conta `initializer`. Esperamos que ela seja tanto `signer` quanto `mutable`, mas se não for, a instrução `CreateAccount` falhará automaticamente, pois requer essas propriedades para o `payer`.
+
+Da mesma forma, se a conta `config` for passada com um `mint_x` ou `mint_y` inválido, qualquer tentativa de depósito no protocolo falhará durante a transferência de token.
+
+À medida que você ganha mais experiência, descobrirá que muitas verificações podem ser omitidas para manter as instruções leves e otimizadas, contando com o sistema e as instruções downstream para impor restrições.
+

--- a/src/app/content/challenges/pinocchio-amm/pt-BR/pages/swap.mdx
+++ b/src/app/content/challenges/pinocchio-amm/pt-BR/pages/swap.mdx
@@ -1,0 +1,185 @@
+# Swap
+
+A instrução `swap` realiza duas tarefas principais:
+
+- Calcula a quantidade de `mint_x` que vamos receber enviando uma certa quantidade de `mint_y` no AMM (e vice-versa) incluindo a taxa.
+- Transfere o token `from` para a vault e o token `to` para a conta de token do usuário
+
+> Como mencionado na seção da instrução `initialize`; vamos inicializar todas as `Associated Token Accounts` fora da nossa instrução para fins de otimização.
+
+<ArticleSection name="Contas Necessárias" id="required-accounts" level="h2" />
+
+Abaixo estão as contas necessárias para este contexto:
+
+- `user`: O usuário que está fazendo o swap de tokens na liquidez do AMM. Deve ser um `signer`.
+- `user_x_ata`: A conta de token associada do usuário para o token X. Esta é a conta que receberá ou enviará o token X para o pool. Deve ser passada como `mutable`.
+- `user_y_ata`: A conta de token associada do usuário para o token Y. Esta é a conta que receberá ou enviará o token Y para o pool. Deve ser passada como `mutable`.
+- `vault_x`: A conta de token que contém todo o token X depositado no pool. Deve ser passada como `mutable`.
+- `vault_y`: A conta de token que contém todo o token Y depositado no pool. Deve ser passada como `mutable`.
+- `config`: A conta de configuração do pool AMM. Armazena todos os parâmetros e estado relevantes do pool.
+- `token program`: A conta do programa SPL Token. Isso é necessário para realizar operações de token como transferências e mint. Deve ser `executable`.
+
+Aqui, novamente, vou deixar a implementação para você:
+
+```rust
+pub struct SwapAccounts<'a> {
+    pub user: &'a AccountInfo,
+    pub user_x_ata: &'a AccountInfo,
+    pub user_y_ata: &'a AccountInfo,
+    pub vault_x: &'a AccountInfo,
+    pub vault_y: &'a AccountInfo,
+    pub config: &'a AccountInfo,
+    pub token_program: &'a AccountInfo,
+}
+
+impl<'a> TryFrom<&'a [AccountInfo]> for SwapAccounts<'a> {
+    type Error = ProgramError;
+
+    fn try_from(accounts: &'a [AccountInfo]) -> Result<Self, Self::Error> {
+        //..
+    }
+}
+```
+
+<ArticleSection name="Dados da Instrução" id="instruction-data" level="h2" />
+
+Aqui estão os dados da instrução que precisamos passar:
+
+- `is_x`: Se este swap está sendo realizado de token X para token Y ou vice-versa; necessário para alinhar as contas corretamente. Deve ser um `[u8]`
+- `amount`: A quantidade de token que o usuário está disposto a enviar em troca do outro token do par. Deve ser um `[u64]`
+- `min`: A quantidade mínima de token que o usuário está disposto a receber na troca pelo `amount`. Deve ser um `[u64]`
+- `expiration`: A expiração desta ordem. Importante para garantir que a transação seja executada em um determinado período de tempo. Deve ser um `[i64]`
+
+Vamos lidar com a implementação do `SwapInstructionData` da mesma forma que a inicialização. Então vou deixar a implementação para você:
+
+```rust
+pub struct SwapInstructionData {
+    pub is_x: bool,
+    pub amount: u64,
+    pub min: u64,
+    pub expiration: i64,
+}
+
+impl<'a> TryFrom<&'a [u8]> for SwapInstructionData {
+    type Error = ProgramError;
+
+    fn try_from(data: &'a [u8]) -> Result<Self, Self::Error> {
+        //..
+    }
+}
+```
+
+> Certifique-se de que qualquer quantidade, como `amount` e `min`, seja maior que zero e que a ordem ainda não tenha expirado usando o sysvar `Clock`.
+
+<ArticleSection name="Lógica da Instrução" id="instruction-logic" level="h2" />
+
+Começamos desserializando tanto o `instruction_data` quanto o `accounts`.
+
+Em seguida, precisamos:
+
+- Carregar a conta `Config` para obter todos os dados dentro dela. Podemos fazer isso usando o helper `Config::load()`.
+- Verificar se o `AmmState` é válido (ou seja, se é igual a `AmmState::Initialized`).
+- Verificar a derivação de `vault_x` e `vault_y` para serem Associated Token Accounts.
+- Desserializar todas as contas de token envolvidas e usar os dados dentro delas para calcular a quantidade a trocar usando o crate `constant-product-curve` e verificando o slippage assim:
+
+```rust
+// Desserializar as contas de token
+let vault_x = unsafe { TokenAccount::from_account_info_unchecked(self.accounts.vault_x)? };
+let vault_y = unsafe { TokenAccount::from_account_info_unchecked(self.accounts.vault_y)? };
+
+// Cálculos de Swap
+let mut curve = ConstantProduct::init(
+    vault_x.amount(),
+    vault_y.amount(),
+    vault_x.amount(),
+    config.fee(),
+    None,
+)
+.map_err(|_| ProgramError::Custom(1))?;
+
+let p = match self.instruction_data.is_x {
+    true => LiquidityPair::X,
+    false => LiquidityPair::Y,
+};
+
+let swap_result = curve
+    .swap(p, self.instruction_data.amount, self.instruction_data.min)
+    .map_err(|_| ProgramError::Custom(1))?;
+
+// Verificar valores corretos
+if swap_result.deposit == 0 || swap_result.withdraw == 0 {
+    return Err(ProgramError::InvalidArgument);
+}
+```
+
+- Agrupar as transferências de token em uma única CPI. Você já viu o padrão de batch em `deposit`, então aqui fazemos o mesmo com as duas instruções `Transfer` e invocamos o programa de token uma vez. Como a transferência da vault ainda requer que o PDA `config` assine, o batch deve terminar com `batch.invoke_signed(&[signer])?;`.
+
+```rust
+const MAX_ACCOUNTS_LEN: usize = Transfer::MAX_ACCOUNTS_LEN * 2;
+const MAX_DATA_LEN: usize = Batch::header_data_len(2) + Transfer::DATA_LEN * 2;
+
+// ...
+
+let mut batch_state = BatchState::new(MAX_ACCOUNTS_LEN, MAX_DATA_LEN);
+let mut batch = batch_state.as_batch()?;
+
+if self.instruction_data.is_x {
+    Transfer::new(
+        // ...
+    )
+    .into_batch(&mut batch)?;
+
+    Transfer::new(
+        // ...
+    )
+    .into_batch(&mut batch)?;
+} else {
+    Transfer::new(
+        // ...
+    )
+    .into_batch(&mut batch)?;
+
+    Transfer::new(
+        // ...
+    )
+    .into_batch(&mut batch)?;
+}
+
+batch.invoke_signed(&[signer])?;
+```
+
+> Certifique-se de que `pinocchio-token` esteja pelo menos na versão `0.6.0` para suportar operações de batch do [p-token](https://solana.com/upgrades/p-token).
+
+Você deve ser proficiente o suficiente para fazer isso por conta própria, então vou deixar a implementação para você:
+
+```rust
+pub struct Swap<'a> {
+    pub accounts: SwapAccounts<'a>,
+    pub instruction_data: SwapInstructionData,
+}
+
+impl<'a> TryFrom<(&'a [u8], &'a [AccountInfo])> for Swap<'a> {
+    type Error = ProgramError;
+
+    fn try_from((data, accounts): (&'a [u8], &'a [AccountInfo])) -> Result<Self, Self::Error> {
+        let accounts = SwapAccounts::try_from(accounts)?;
+        let instruction_data = SwapInstructionData::try_from(data)?;
+
+        // Retorna a struct inicializada
+        Ok(Self {
+            accounts,
+            instruction_data,
+        })
+    }
+}
+impl<'a> Swap<'a> {
+    pub const DISCRIMINATOR: &'a u8 = &3;
+
+    pub fn process(&mut self) -> ProgramResult {
+        //..
+
+        Ok(())
+    }
+}
+```
+

--- a/src/app/content/challenges/pinocchio-amm/pt-BR/pages/withdraw.mdx
+++ b/src/app/content/challenges/pinocchio-amm/pt-BR/pages/withdraw.mdx
@@ -1,0 +1,154 @@
+# Withdraw
+
+A instrução `withdraw` realiza três tarefas principais:
+
+- Retira os tokens `mint_x` e `mint_y` com base na quantidade de LP que o usuário deseja `burn`.
+- Calcula a quantidade a ser retirada e verifica se a quantidade não é menor que `mint_x` e `mint_y` designados pelo usuário.
+- Realiza o burn da quantidade correta de `mint_lp` da ATA do usuário.
+
+> Como mencionado na seção da instrução `initialize`; vamos inicializar todas as `Associated Token Accounts` fora da nossa instrução para fins de otimização.
+
+<ArticleSection name="Contas Necessárias" id="required-accounts" level="h2" />
+
+Abaixo estão as contas necessárias para este contexto:
+
+- `user`: O usuário que está retirando os tokens da liquidez do AMM. Deve ser um `signer`.
+- `mint_lp`: A conta Mint que representará a liquidez do pool. Deve ser passada como `mutable`.
+- `vault_x`: A conta de token que contém todo o token X depositado no pool. Deve ser passada como `mutable`.
+- `vault_y`: A conta de token que contém todo o token Y depositado no pool. Deve ser passada como `mutable`.
+- `user_x_ata`: A conta de token associada do usuário para o token X. Esta é a conta de destino para a qual o token X do usuário será transferido do pool. Deve ser passada como `mutable`.
+- `user_y_ata`: A conta de token associada do usuário para o token Y. Esta é a conta de destino para a qual o token Y do usuário será transferido do pool. Deve ser passada como `mutable`.
+- `user_lp_ata`: A conta de token associada do usuário para tokens LP. Esta é a conta de origem de onde os tokens LP serão queimados. Deve ser passada como `mutable`.
+- `config`: A conta de configuração do pool AMM. Armazena todos os parâmetros e estado relevantes do pool.
+- `token program`: A conta do programa SPL Token. Isso é necessário para realizar operações de token como transferências e mint. Deve ser `executable`.
+
+Aqui, novamente, vou deixar a implementação para você:
+
+```rust
+pub struct WithdrawAccounts<'a> {
+    pub user: &'a AccountInfo,
+    pub mint_lp: &'a AccountInfo,
+    pub vault_x: &'a AccountInfo,
+    pub vault_y: &'a AccountInfo,
+    pub user_x_ata: &'a AccountInfo,
+    pub user_y_ata: &'a AccountInfo,
+    pub user_lp_ata: &'a AccountInfo,
+    pub config: &'a AccountInfo,
+    pub token_program: &'a AccountInfo,
+}
+
+impl<'a> TryFrom<&'a [AccountInfo]> for WithdrawAccounts<'a> {
+  type Error = ProgramError;
+
+  fn try_from(accounts: &'a [AccountInfo]) -> Result<Self, Self::Error> {
+    //..
+  }
+}
+```
+
+<ArticleSection name="Dados da Instrução" id="instruction-data" level="h2" />
+
+Aqui estão os dados da instrução que precisamos passar:
+
+- `amount`: A quantidade de tokens LP que o usuário deseja queimar. Deve ser um `[u64]`
+- `min_x`: A quantidade mínima de token X que o usuário está disposto a retirar. Deve ser um `[u64]`
+- `min_y`: A quantidade mínima de token Y que o usuário está disposto a retirar. Deve ser um `[u64]`
+- `expiration`: A expiração desta ordem. Importante para garantir que a transação seja executada em um determinado período de tempo. Deve ser um `[i64]`
+
+Vamos lidar com a implementação do `WithdrawInstructionData` da mesma forma que a inicialização. Então vou deixar a implementação para você:
+
+```rust
+pub struct WithdrawInstructionData {
+    pub amount: u64,
+    pub min_x: u64,
+    pub min_y: u64,
+    pub expiration: i64,
+}
+
+impl<'a> TryFrom<&'a [u8]> for WithdrawInstructionData {
+    type Error = ProgramError;
+
+    fn try_from(data: &'a [u8]) -> Result<Self, Self::Error> {
+        //..
+    }
+}
+```
+
+> Certifique-se de que qualquer quantidade, como `amount`, `min_y` e `min_x`, seja maior que zero e que a ordem ainda não tenha expirado usando o sysvar `Clock`.
+
+<ArticleSection name="Lógica da Instrução" id="instruction-logic" level="h2" />
+
+Começamos desserializando tanto o `instruction_data` quanto o `accounts`.
+
+Em seguida, precisamos:
+
+- Carregar a conta `Config` para obter todos os dados dentro dela. Podemos fazer isso usando o helper `Config::load()`.
+- Verificar se o `AmmState` é válido (ou seja, se não é igual a `AmmState::Disabled`).
+- Verificar a derivação de `vault_x` e `vault_y` para serem Associated Token Accounts.
+- Desserializar todas as contas de token envolvidas e usar os dados dentro delas para calcular a quantidade a retirar usando o crate `constant-product-curve` e verificando o slippage assim:
+
+```rust
+let mint_lp = unsafe { Mint::from_account_info_unchecked(self.accounts.mint_lp)? };
+let vault_x = unsafe { TokenAccount::from_account_info_unchecked(self.accounts.vault_x)? };
+let vault_y = unsafe { TokenAccount::from_account_info_unchecked(self.accounts.vault_y)? };
+
+let (x, y) = match mint_lp.supply() == self.instruction_data.amount {
+    true => (vault_x.amount(), vault_y.amount()),
+    false => {
+        let amounts = ConstantProduct::xy_withdraw_amounts_from_l(
+            vault_x.amount(),
+            vault_y.amount(),
+            mint_lp.supply(),
+            self.instruction_data.amount,
+            6,
+        )
+        .map_err(|_| ProgramError::InvalidArgument)?;
+
+        (amounts.x, amounts.y)
+    }
+};
+
+// Verificar slippage
+if !(x >= self.instruction_data.min_x && y >= self.instruction_data.min_y) {
+    return Err(ProgramError::InvalidArgument);
+}
+```
+
+- Transferir as quantidades das vaults para as contas de token do usuário e queimar a quantidade apropriada de tokens LP da conta de token do usuário. Assim como fizemos na instrução `Deposit`, use um único `Batch` para que ambas as transferências e o burn sejam feitos em uma única CPI.
+
+> A `authority` de `vault_x` e `vault_y` é a conta `config`
+
+Você deve ser proficiente o suficiente para fazer isso por conta própria, então vou deixar a implementação para você:
+
+```rust
+pub struct Withdraw<'a> {
+    pub accounts: WithdrawAccounts<'a>,
+    pub instruction_data: WithdrawInstructionData,
+}
+
+impl<'a> TryFrom<(&'a [u8], &'a [AccountInfo])> for Withdraw<'a> {
+    type Error = ProgramError;
+
+    fn try_from((data, accounts): (&'a [u8], &'a [AccountInfo])) -> Result<Self, Self::Error> {
+        let accounts = WithdrawAccounts::try_from(accounts)?;
+        let instruction_data = WithdrawInstructionData::try_from(data)?;
+
+        // Retorna a struct inicializada
+        Ok(Self {
+            accounts,
+            instruction_data,
+        })
+    }
+}
+
+impl<'a> Withdraw<'a> {
+    pub const DISCRIMINATOR: &'a u8 = &2;
+
+    pub fn process(&mut self) -> ProgramResult {
+        //..
+
+        Ok(())
+    }
+}
+```
+


### PR DESCRIPTION
## Resolves #401

@dhl noticed that the Pinocchio AMM challenge pt-BR translation was incomplete — the `pages/` directory was missing from `src/app/content/challenges/pinocchio-amm/pt-BR/`.

### Changes
Added Brazilian Portuguese translations for all 5 challenge step pages:
- `pages/conclusion.mdx`
- `pages/deposit.mdx`
- `pages/initialize.mdx`
- `pages/swap.mdx`
- `pages/withdraw.mdx`

### Translation approach
- All prose/explanatory text translated to Brazilian Portuguese
- Code blocks, variable names, and technical identifiers kept in English
- `ArticleSection` component name attributes kept in English for routing, display text translated
- Matches the translation style used in the existing pt-BR `challenge.mdx` and `verify.mdx`

@BretasArthur1 could you review for accuracy?